### PR TITLE
Use the current layout for keyboard shortcuts

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -23,13 +23,13 @@ type Props = RouteComponentProps<{}>;
 
 class Museeks extends React.Component<Props> {
   onKey = async (e: KeyboardEvent) => {
-    switch (e.code) {
-      case 'Space':
+    switch (e.key) {
+      case ' ':
         e.preventDefault();
         e.stopPropagation();
         await PlayerActions.playPause();
         break;
-      case 'Comma':
+      case ',':
         if (isCtrlKey(e)) {
           e.preventDefault();
           e.stopPropagation();

--- a/src/ui/components/Header/Header.tsx
+++ b/src/ui/components/Header/Header.tsx
@@ -33,7 +33,7 @@ class Header extends React.Component<Props> {
 
   onKey (e: KeyboardEvent) {
     // ctrl-f shortcut
-    if (isCtrlKey(e) && e.code === 'KeyF') {
+    if (isCtrlKey(e) && e.key.toLowerCase() === 'f') {
       if (this.input.current) {
         // @ts-ignore
         // tslint:disable-next-line


### PR DESCRIPTION
Currently the shortcuts always use the position of where the key would be on a QWERTY keyboard. This makes it difficult for users who use layouts for their specific region which might differ.

The current implementation does not know whether Shift is being pressed simultaneously so Ctrl+F and Ctrl+f would have the same result (i.e. works with caps lock on). I used toLowerCase() for Ctrl+F for this, for space it doesn't matter but for the comma it doesn't work since depending on layout there could be completely different special characters on Shift+Comma and toLowerCase() would not return a comma.

This is a bit inconsistent so it would be great to hear some thoughts on this.

This also coincidentally stops Meta+Space from pause/playing which I think is a welcome extension since that switches keyboard layout on Windows and GNOME.