### PR TITLE
Fix failing m3u imports

### DIFF
--- a/src/ui/utils/utils-m3u.ts
+++ b/src/ui/utils/utils-m3u.ts
@@ -18,7 +18,7 @@ export const parse = (filePath: string): string[] => {
     const decodedContent = iconv.decode(content, encoding);
 
     const files = decodedContent
-      .split('\n')
+      .split(/\r?\n/)
       .reduce((acc, line) => {
         if (line.length === 0) {
           return acc;


### PR DESCRIPTION
Fixes https://github.com/martpie/museeks/issues/482

Carriage returns at the end of the lines were messing things up. This checks if a carriage return is at the end of the current line and removes it if it finds one.