### PR TITLE
Issue #514

### DIFF
--- a/src/ui/components/PlayingBarInfo/PlayingBarInfo.tsx
+++ b/src/ui/components/PlayingBarInfo/PlayingBarInfo.tsx
@@ -172,7 +172,7 @@ class PlayingBarInfo extends React.Component<Props, State> {
             onMouseMove={this.showTooltip}
             onMouseLeave={this.hideTooltip}
           >
-            <div className={styles.progressBar} style={elapsed < 1 ? {transform: `scale3d(${elapsed}, 1, 1)` } : {display: "none"}} />
+            <div className={styles.progressBar} style={elapsed <= 1 ? {transform: `scale3d(${elapsed}, 1, 1)` } : {display: "none"}} />
           </div>
         </div>
       </div>

--- a/src/ui/components/PlayingBarInfo/PlayingBarInfo.tsx
+++ b/src/ui/components/PlayingBarInfo/PlayingBarInfo.tsx
@@ -172,7 +172,7 @@ class PlayingBarInfo extends React.Component<Props, State> {
             onMouseMove={this.showTooltip}
             onMouseLeave={this.hideTooltip}
           >
-            <div className={styles.progressBar} style={{ transform: `scale3d(${elapsed}, 1, 1)` }} />
+            <div className={styles.progressBar} style={elapsed < 1 ? {transform: `scale3d(${elapsed}, 1, 1)` } : {display: "none"}} />
           </div>
         </div>
       </div>

--- a/src/ui/utils/utils.ts
+++ b/src/ui/utils/utils.ts
@@ -204,7 +204,7 @@ export const getMetadata = async (trackPath: string): Promise<Track> => {
     metadata.loweredMetas = getLoweredMeta(metadata);
 
     // Let's try another wat to retrieve a track duration
-    if (!metadata.duration) {
+    if (metadata.duration < 0.5) {
       try {
         metadata.duration = await getAudioDuration(trackPath);
       } catch (err) {


### PR DESCRIPTION
This fixes the 2 issues I mentioned in #514 - was easier than I expected.

PlayingBarInfo.tsx: hides the (blue) playing bar if the elapsed time has scaled past 1. Ideally this never happens of course.

utils.ts: music-metadata determined several songs to have inaccurately short durations (0.042666666666666665s) not picked up by `!metadata.duration` . On this event default to secondary audio duration retrieval. Less than half a second seems reasonable for a double check?

