### PR TITLE
max height is full window, -header and -footer

### DIFF
--- a/src/ui/App.css
+++ b/src/ui/App.css
@@ -10,6 +10,7 @@
   position: relative;
   display: flex;
   flex-direction: column;
+  max-height: calc(100vh - 50px - 30px);
 }
 
 .content {


### PR DESCRIPTION
Getting real close to my perfect media player!

The problem is when playlists go beyond ~14, the footer is knocked way down the page & prevents scrolling.
![Screenshot from 2020-02-18 13-10-28](https://user-images.githubusercontent.com/1429672/74779166-d655d780-5251-11ea-9ad3-9a60f84e7f5c.png)

Giving the main content 100% window height minus the header+footer height worked for me, but open to your testing and suggestions.

Here are screenshots at different viewpoints (all hidpi)

![Screenshot from 2020-02-18 13-16-53](https://user-images.githubusercontent.com/1429672/74779265-ff766800-5251-11ea-90e6-34780ecd8d15.png)

![Screenshot from 2020-02-18 13-13-44](https://user-images.githubusercontent.com/1429672/74779280-069d7600-5252-11ea-964f-00208f368356.png)

![Screenshot from 2020-02-18 13-14-28](https://user-images.githubusercontent.com/1429672/74779286-0a30fd00-5252-11ea-82b9-a8d78a321e48.png)
