### PR TITLE
Introduce Gapless Playback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -252,6 +252,20 @@
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
       "dev": true
     },
+    "@synesthesia-project/gapless-meta": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@synesthesia-project/gapless-meta/-/gapless-meta-0.0.1.tgz",
+      "integrity": "sha512-WDldxaJ3E5ueR+0GW2MLafnXLXLDOClny/venpMpbyAkHSSJw8N9oScy69bUfmNp9poRmxsbNYF0xSgrWcAPLA=="
+    },
+    "@synesthesia-project/precise-audio": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@synesthesia-project/precise-audio/-/precise-audio-0.2.3.tgz",
+      "integrity": "sha512-oB4JWsMzjEN+AT7IEvOxFMnthlO4MPfJn2onwwlUxtR+K8Nj1scXpmYtNUejMdFSXg8fvfGzvJpkLlcTaSr+RA==",
+      "requires": {
+        "@synesthesia-project/gapless-meta": "^0.0.1",
+        "soundbank-pitch-shift": "~1.0.3"
+      }
+    },
     "@szmarczak/http-timer": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
@@ -2600,6 +2614,11 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.9.tgz",
       "integrity": "sha512-xz39Sb4+OaTsULgUERcCk+TJj8ylkL4aSVDQiX/ksxbELSqwkgt4d4RD7fovIdgJGSuNYqwZEiVjYY5l0ask+Q==",
       "dev": true
+    },
+    "custom-audio-node": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/custom-audio-node/-/custom-audio-node-0.3.1.tgz",
+      "integrity": "sha1-h0TN+lAaij7EADkXDlkCYy4j49k="
     },
     "cyclist": {
       "version": "1.0.1",
@@ -10188,6 +10207,14 @@
       "dev": true,
       "requires": {
         "is-plain-obj": "^1.0.0"
+      }
+    },
+    "soundbank-pitch-shift": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/soundbank-pitch-shift/-/soundbank-pitch-shift-1.0.3.tgz",
+      "integrity": "sha1-n0kEPdJqc9ifMUgo3Wm0MyKvVbs=",
+      "requires": {
+        "custom-audio-node": "^0.3.0"
       }
     },
     "source-list-map": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "package:checksums": "bash scripts/checksum.sh"
   },
   "dependencies": {
+    "@synesthesia-project/precise-audio": "^0.2.3",
     "bluebird": "3.7.2",
     "chardet": "0.8.0",
     "classnames": "2.2.6",

--- a/src/ui/actions/AppActions.ts
+++ b/src/ui/actions/AppActions.ts
@@ -43,6 +43,7 @@ const init = async () => {
 
   // Bind player events
   // Audio Events
+  Player.getAudio().addEventListener('next', PlayerActions.next);
   Player.getAudio().addEventListener('ended', PlayerActions.next);
   Player.getAudio().addEventListener('error', PlayerActions.audioError);
   Player.getAudio().addEventListener('timeupdate', async () => {

--- a/src/ui/actions/QueueActions.ts
+++ b/src/ui/actions/QueueActions.ts
@@ -3,18 +3,22 @@ import types from '../constants/action-types';
 
 import * as app from '../lib/app';
 import Player from '../lib/player';
-import * as utils from '../utils/utils';
 
 import { Track } from '../../shared/types/interfaces';
+import { updatePlayerTrackQueue } from '../reducers/player';
 
 /**
  * Start audio playback from the queue
  */
 export const start = async (index: number) => {
-  const { queue } = store.getState().player;
-  const uri = utils.parseUri(queue[index].path);
+  // TODO (y.solovyov | martpie): calling getState is a hack.
+  const { queue, repeat } = store.getState().player;
 
-  Player.setAudioSrc(uri);
+  updatePlayerTrackQueue({
+    queue,
+    queueCursor: index,
+    repeat
+  });
   await Player.play();
 
   store.dispatch({

--- a/src/ui/lib/player.ts
+++ b/src/ui/lib/player.ts
@@ -1,4 +1,5 @@
 import * as app from './app';
+import PreciseAudio from '@synesthesia-project/precise-audio';
 
 interface PlayerOptions {
   playbackRate?: number;
@@ -8,7 +9,7 @@ interface PlayerOptions {
 }
 
 class Player {
-  private audio: HTMLAudioElement;
+  private audio: PreciseAudio;
   private durationThresholdReached: boolean;
   public threshold: number;
 
@@ -21,11 +22,9 @@ class Player {
       ...options
     };
 
-    this.audio = new Audio();
+    this.audio = new PreciseAudio();
 
     this.audio.defaultPlaybackRate = mergedOptions.playbackRate;
-    // eslint-disable-next-line
-    // @ts-ignore
     this.audio.setSinkId(mergedOptions.audioOutputDevice);
     this.audio.playbackRate = mergedOptions.playbackRate;
     this.audio.volume = mergedOptions.volume;
@@ -81,8 +80,6 @@ class Player {
   }
 
   async setOutputDevice(deviceId: string) {
-    // eslint-disable-next-line
-    // @ts-ignore
     await this.audio.setSinkId(deviceId);
   }
 

--- a/src/ui/lib/player.ts
+++ b/src/ui/lib/player.ts
@@ -1,5 +1,5 @@
-import * as app from './app';
 import PreciseAudio from '@synesthesia-project/precise-audio';
+import * as app from './app';
 
 interface PlayerOptions {
   playbackRate?: number;
@@ -83,10 +83,11 @@ class Player {
     await this.audio.setSinkId(deviceId);
   }
 
-  setAudioSrc(src: string) {
+  setTracks(srcs: string[]) {
+    console.log('setTracks', srcs);
     // When we change song, need to update the thresholdReached indicator.
     this.durationThresholdReached = false;
-    this.audio.src = src;
+    this.audio.updateTracks(...srcs);
   }
 
   setAudioCurrentTime(currentTime: number) {


### PR DESCRIPTION
This PR introduces gapless playback to museeks!

The core of the functionality is actually in an [external library](https://www.npmjs.com/package/@synesthesia-project/precise-audio) that I put together (mostly for the purposes of getting gapless playback to work in museeks).

The result is a somewhat less intrusive PR, most of the changes are in `src/ui/reducers/player.ts` to ensure that whenever the player or queue state changes, the `PreciseAudio` instance is updated with the expected queue.

This now also introduces an `AudioContext` and audio graph into museeks, which means that we can go ahead and implement #127 and other stuff after this!

Fixes #128
Fixes #31

I've tested this mostly on LAME-Encoded MP3s, but there are many more codecs that need to be supported, the good news is that now that the boilerplate is in, adding new codecs is simply a matter of adding them in [`@synesthesia-project/gapless-meta`](https://www.npmjs.com/package/@synesthesia-project/gapless-meta), and won't require any more plumbing. If you have any examples of gapless audio files that don't work, please let me know.