### PR TITLE
Normalize backslashes in track paths to fix broken playlists on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Please consider that **`master` is unstable**.
 - `git clone git@github.com:martpie/museeks.git`
 - `cd museeks`
 - `npm ci`
-- `npm modules:rebuild`
+- `npm run modules:rebuild`
 - `npm run build` or `npm run dev`
 - `npm run museeks` or `npm run museeks:debug`
 
@@ -63,8 +63,8 @@ Please consider that **`master` is unstable**.
 
 - `rm -rf node_modules dist build`
 - `npm ci`
-- `npm modules:rebuild`
-- `npm build`
+- `npm run modules:rebuild`
+- `npm run build`
 - `npm run package:lmw`
 
 ## Troubleshooting

--- a/src/ui/actions/LibraryActions.ts
+++ b/src/ui/actions/LibraryActions.ts
@@ -118,7 +118,7 @@ const scanTracks = async (paths: string[]): Promise<void> => {
       });
 
       scanQueue.on('success', () => {
-        // Every 10 scans, update progress bar
+        // Every 100 scans, update progress bar
         if (scan.processed % 100 === 0) {
           // Progress bar update
           store.dispatch({
@@ -149,6 +149,9 @@ const scanTracks = async (paths: string[]): Promise<void> => {
       paths.forEach((filePath) => {
         scanQueue.push(async (callback: Function) => {
           try {
+            // Normalize (back)slashes on Windows
+            filePath = path.resolve(filePath);
+
             // Check if there is an existing record in the DB
             const existingDoc = await app.models.Track.findOneAsync({ path: filePath });
 


### PR DESCRIPTION
On Windows, museeks@0.11.4 adds tracks with slash paths ("C:/path/track.mp3"), but interprets playlist tracks with backslash paths ("C:\path\track.mp3"). Without resolving track paths (thus normalizing slashes to backslashes), playlists will never find tracks to add, and thus will always be empty.

You can see this by creating a test directory, and placing a `track.mp3` and a `playlist.m3u` in the directory. In `playlist.m3u`, have one line adding the track:

```
track.mp3
```

Upon adding the directory to the library on museeks@0.11.4, the playlist will be empty (here, `resolved filePath` is without the resolution; I just forgot to take out the `console.log`):

![image](https://user-images.githubusercontent.com/20709601/80831671-7d3ae600-8ba8-11ea-8f36-b14bfac5c612.png)

However, by resolving the `filePath` for each track, the playlist will be interpreted correctly:

![image](https://user-images.githubusercontent.com/20709601/80831704-8c219880-8ba8-11ea-9c2c-0db70ce2e839.png)

The PR also updates a small number of outdated comments.