### PR TITLE
Escape special regex characters in library path scan

### DIFF
--- a/src/ui/actions/LibraryActions.ts
+++ b/src/ui/actions/LibraryActions.ts
@@ -205,7 +205,8 @@ export const add = async (pathsToScan: string[]) => {
 
     // 3. Scan all the directories with globby
     const globbies = folders.map((folder) => {
-      const pattern = `${folder.replace(/\\/g, '/')}/**/*.*`;
+      // Normalize slashes and escape regex special characters
+      const pattern = `${folder.replace(/\\/g, '/').replace(/([$^*+?()\[\]])/g, '\\$1')}/**/*.*`;
 
       console.log(pattern);
       return globby(pattern, { followSymbolicLinks: true });


### PR DESCRIPTION
Directory path patterns passed to `globby` may contain special regex characters which will not parse correctly, leading `museeks` to fail to scan some directories containing those characters. This PR escapes the regex characters in directory paths.

The current (buggy) behavior is visible by creating a directory named `(test)` (`(` and `)` are special regex characters) and placing within it any `.mp3` file. Attempting to add the `(test)` directory to the library will not add any `.mp3` files within.

The relevant special characters are `$^*+?()[]`. More information is at [`fast-glob`](https://github.com/mrmlnc/fast-glob#advanced-syntax) and [`micromatch`](https://github.com/micromatch/picomatch#matching-special-characters-as-literals).