### PR TITLE
Calculate PlaylistsNav height and scroll correctly

### DIFF
--- a/src/ui/components/PlaylistsNav/PlaylistsNav.css
+++ b/src/ui/components/PlaylistsNav/PlaylistsNav.css
@@ -1,4 +1,6 @@
 .playlists-nav {
+  display: flex;
+  flex-flow: column;
   width: 200px;
   border-right: 1px solid var(--border-color);
   background-color: var(--sidebar-bg);
@@ -8,6 +10,7 @@
 }
 
 .playlists-nav__header {
+  flex: 0 0 auto;
   display: flex;
   align-items: center;
 }
@@ -43,7 +46,7 @@
 }
 
 .playlists-nav__body {
-  max-height: 100%;
+  flex: 1 1 auto;
   overflow: auto;
 }
 


### PR DESCRIPTION
Currently, the playlist navigation miscalculates its height and doesn't invoke the scrollbar sometimes and hides the last playlist entry.
![image](https://user-images.githubusercontent.com/20709601/97758628-a85dae00-1ad5-11eb-9704-f2e99341bedb.png)
This fixes the height calculation in CSS.
![image](https://user-images.githubusercontent.com/20709601/97758642-b14e7f80-1ad5-11eb-8fb5-49dabdfc6cc5.png)
