### PR TITLE
Add year, track number, custom sorting orders

### DIFF
--- a/src/renderer/components/TrackRow/TrackRow.tsx
+++ b/src/renderer/components/TrackRow/TrackRow.tsx
@@ -140,6 +140,7 @@ export default class TrackRow extends React.PureComponent<Props, State> {
         <div className={`${styles.cell} ${cellStyles.cellTrackPlaying}`}>
           {this.props.isPlaying ? <PlayingIndicator /> : null}
         </div>
+        <div className={`${styles.cell} ${cellStyles.cellYear}`}>{track.year}</div>
         <div className={`${styles.cell} ${cellStyles.cellTrack}`}>{track.title}</div>
         <div className={`${styles.cell} ${cellStyles.cellDuration}`}>{parseDuration(track.duration)}</div>
         <div className={`${styles.cell} ${cellStyles.cellArtist}`}>{track.artist.sort().join(', ')}</div>

--- a/src/renderer/components/TrackRow/TrackRow.tsx
+++ b/src/renderer/components/TrackRow/TrackRow.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import cx from 'classnames';
 
 import PlayingIndicator from '../PlayingIndicator/PlayingIndicator';
-import { parseDuration } from '../../lib/utils';
+import { getDiskTrack, parseDuration } from '../../lib/utils';
 import { TrackModel } from '../../../shared/types/museeks';
 
 import cellStyles from '../TracksListHeader/TracksListHeader.module.css';
@@ -141,6 +141,7 @@ export default class TrackRow extends React.PureComponent<Props, State> {
           {this.props.isPlaying ? <PlayingIndicator /> : null}
         </div>
         <div className={`${styles.cell} ${cellStyles.cellYear}`}>{track.year}</div>
+        <div className={`${styles.cell} ${cellStyles.cellDiskTrack}`}>{getDiskTrack(track)}</div>
         <div className={`${styles.cell} ${cellStyles.cellTrack}`}>{track.title}</div>
         <div className={`${styles.cell} ${cellStyles.cellDuration}`}>{parseDuration(track.duration)}</div>
         <div className={`${styles.cell} ${cellStyles.cellArtist}`}>{track.artist.sort().join(', ')}</div>

--- a/src/renderer/components/TracksListHeader/TracksListHeader.module.css
+++ b/src/renderer/components/TracksListHeader/TracksListHeader.module.css
@@ -15,6 +15,7 @@
   flex: 1;
 }
 
+.cellYear,
 .cellDuration {
   width: 7%;
 }

--- a/src/renderer/components/TracksListHeader/TracksListHeader.module.css
+++ b/src/renderer/components/TracksListHeader/TracksListHeader.module.css
@@ -16,6 +16,7 @@
 }
 
 .cellYear,
+.cellDiskTrack,
 .cellDuration {
   width: 7%;
 }

--- a/src/renderer/components/TracksListHeader/TracksListHeader.tsx
+++ b/src/renderer/components/TracksListHeader/TracksListHeader.tsx
@@ -14,23 +14,19 @@ interface OwnProps {
 }
 
 interface InjectedProps {
-  sort?: LibrarySort;
+  sort?: LibrarySort[];
 }
 
 type Props = OwnProps & InjectedProps;
 
 class TracksListHeader extends React.Component<Props> {
-  static getIcon = (sort: LibrarySort | undefined, sortType: SortBy) => {
-    if (sort && sort.by === sortType) {
-      if (sort.order === SortOrder.ASC) {
-        return 'angle-up';
-      }
-
-      // Must be DSC then
-      return 'angle-down';
+  static getIcon = (sorts: LibrarySort[] | undefined, sortType: SortBy) => {
+    const sort = sorts?.find(s => s.by === sortType);
+    if (!sort) {
+      return null;
     }
 
-    return null;
+    return sort.order === SortOrder.ASC ? 'angle-up' : 'angle-down';
   };
 
   render() {

--- a/src/renderer/components/TracksListHeader/TracksListHeader.tsx
+++ b/src/renderer/components/TracksListHeader/TracksListHeader.tsx
@@ -42,6 +42,12 @@ class TracksListHeader extends React.Component<Props> {
           icon={TracksListHeader.getIcon(sort, SortBy.YEAR)}
         />
         <TracksListHeaderCell
+          className={styles.cellDiskTrack}
+          title='Track'
+          sortBy={enableSort ? SortBy.TRACK : null}
+          icon={TracksListHeader.getIcon(sort, SortBy.TRACK)}
+        />
+        <TracksListHeaderCell
           className={styles.cellTrack}
           title='Title'
           sortBy={enableSort ? SortBy.TITLE : null}

--- a/src/renderer/components/TracksListHeader/TracksListHeader.tsx
+++ b/src/renderer/components/TracksListHeader/TracksListHeader.tsx
@@ -40,6 +40,12 @@ class TracksListHeader extends React.Component<Props> {
       <div className={styles.tracksListHeader}>
         <TracksListHeaderCell className={styles.cellTrackPlaying} title='&nbsp;' />
         <TracksListHeaderCell
+          className={styles.cellYear}
+          title='Year'
+          sortBy={enableSort ? SortBy.YEAR : null}
+          icon={TracksListHeader.getIcon(sort, SortBy.YEAR)}
+        />
+        <TracksListHeaderCell
           className={styles.cellTrack}
           title='Title'
           sortBy={enableSort ? SortBy.TITLE : null}

--- a/src/renderer/constants/sort-orders.ts
+++ b/src/renderer/constants/sort-orders.ts
@@ -1,43 +1,28 @@
 import { Track, SortOrder, SortBy } from '../../shared/types/museeks';
+import { LibrarySort } from "../store/reducers/library";
 
 // For perforances reasons, otherwise _.orderBy will perform weird check
 // the is far more resource/time impactful
 const parseArtist = (t: Track): string => t.loweredMetas.artist[0].toString();
 const parseGenre = (t: Track): string => t.loweredMetas.genre.toString();
 
-// Declarations
-const sortOrders = {
-  [SortBy.ARTIST]: {
-    [SortOrder.ASC]: [
-      // Default
-      [parseArtist, 'year', 'loweredMetas.album', 'disk.no', 'track.no'],
-      null,
-    ],
-    [SortOrder.DSC]: [[parseArtist, 'year', 'loweredMetas.album', 'disk.no', 'track.no'], ['desc']],
-  },
-  [SortBy.TITLE]: {
-    [SortOrder.ASC]: [['loweredMetas.title', parseArtist, 'year', 'loweredMetas.album', 'disk.no', 'track.no'], null],
-    [SortOrder.DSC]: [
-      ['loweredMetas.title', parseArtist, 'year', 'loweredMetas.album', 'disk.no', 'track.no'],
-      ['desc'],
-    ],
-  },
-  [SortBy.DURATION]: {
-    [SortOrder.ASC]: [['duration', parseArtist, 'year', 'loweredMetas.album', 'disk.no', 'track.no'], null],
-    [SortOrder.DSC]: [['duration', parseArtist, 'year', 'loweredMetas.album', 'disk.no', 'track.no'], ['desc']],
-  },
-  [SortBy.ALBUM]: {
-    [SortOrder.ASC]: [['loweredMetas.album', parseArtist, 'year', 'disk.no', 'track.no'], null],
-    [SortOrder.DSC]: [['loweredMetas.album', parseArtist, 'year', 'disk.no', 'track.no'], ['desc']],
-  },
-  [SortBy.GENRE]: {
-    [SortOrder.ASC]: [[parseGenre, parseArtist, 'year', 'loweredMetas.album', 'disk.no', 'track.no'], null],
-    [SortOrder.DSC]: [[parseGenre, parseArtist, 'year', 'loweredMetas.album', 'disk.no', 'track.no'], ['desc']],
-  },
-  [SortBy.YEAR]: {
-    [SortOrder.ASC]: [['year', parseArtist, 'loweredMetas.album', 'disk.no', 'track.no'], null],
-    [SortOrder.DSC]: [['year', parseArtist, 'loweredMetas.album', 'disk.no', 'track.no'], ['desc']],
-  }
+const sortByMapping = {
+  [SortBy.ARTIST]: parseArtist,
+  [SortBy.TITLE]: 'loweredMetas.title',
+  [SortBy.DURATION]: 'duration',
+  [SortBy.ALBUM]: 'loweredMetas.album',
+  [SortBy.GENRE]: parseGenre,
+  [SortBy.YEAR]: 'year',
 };
 
-export default sortOrders;
+const sortOrderMapping = {
+  [SortOrder.ASC]: 'asc',
+  [SortOrder.DSC]: 'desc',
+}
+
+export function createSortOrder(config: LibrarySort[]) {
+  const by = [...config.map(s => sortByMapping[s.by]), 'disk.no', 'track.no'];
+  const order = [...config.map(s => sortOrderMapping[s.order]), 'asc', 'asc'];
+
+  return [by, order];
+}

--- a/src/renderer/constants/sort-orders.ts
+++ b/src/renderer/constants/sort-orders.ts
@@ -34,6 +34,10 @@ const sortOrders = {
     [SortOrder.ASC]: [[parseGenre, parseArtist, 'year', 'loweredMetas.album', 'disk.no', 'track.no'], null],
     [SortOrder.DSC]: [[parseGenre, parseArtist, 'year', 'loweredMetas.album', 'disk.no', 'track.no'], ['desc']],
   },
+  [SortBy.YEAR]: {
+    [SortOrder.ASC]: [['year', parseArtist, 'loweredMetas.album', 'disk.no', 'track.no'], null],
+    [SortOrder.DSC]: [['year', parseArtist, 'loweredMetas.album', 'disk.no', 'track.no'], ['desc']],
+  }
 };
 
 export default sortOrders;

--- a/src/renderer/constants/sort-orders.ts
+++ b/src/renderer/constants/sort-orders.ts
@@ -1,10 +1,12 @@
 import { Track, SortOrder, SortBy } from '../../shared/types/museeks';
+import { getDiskTrack } from "../lib/utils";
 import { LibrarySort } from "../store/reducers/library";
 
 // For perforances reasons, otherwise _.orderBy will perform weird check
 // the is far more resource/time impactful
 const parseArtist = (t: Track): string => t.loweredMetas.artist[0].toString();
 const parseGenre = (t: Track): string => t.loweredMetas.genre.toString();
+const parseTrack = (t: Track): string => getDiskTrack(t);
 
 const sortByMapping = {
   [SortBy.ARTIST]: parseArtist,
@@ -13,6 +15,7 @@ const sortByMapping = {
   [SortBy.ALBUM]: 'loweredMetas.album',
   [SortBy.GENRE]: parseGenre,
   [SortBy.YEAR]: 'year',
+  [SortBy.TRACK]: parseTrack,
 };
 
 const sortOrderMapping = {
@@ -21,8 +24,8 @@ const sortOrderMapping = {
 }
 
 export function createSortOrder(config: LibrarySort[]) {
-  const by = [...config.map(s => sortByMapping[s.by]), 'disk.no', 'track.no'];
-  const order = [...config.map(s => sortOrderMapping[s.order]), 'asc', 'asc'];
+  const by = [...config.map(s => sortByMapping[s.by])];
+  const order = [...config.map(s => sortOrderMapping[s.order])];
 
   return [by, order];
 }

--- a/src/renderer/lib/utils.ts
+++ b/src/renderer/lib/utils.ts
@@ -212,3 +212,18 @@ export const getMetadata = async (trackPath: string): Promise<Track> => {
 
   return basicMetadata;
 };
+
+/**
+ * Format track information to DD.TT where DD is disk no and TT is track.no
+ */
+export function getDiskTrack(track: Track) {
+  const formatNo = (no: number|null, of: number|null) => {
+    const length = Math.max(2, of?.toString().length ?? 2);
+    return no?.toString().padStart(length, '0') ?? "";
+  }
+
+  const diskNo = formatNo(track.disk.no, track.disk.of);
+  const trackNo = formatNo(track.track.no, track.track.of);
+
+  return diskNo.length > 0 && trackNo.length > 0 ? `${diskNo}.${trackNo}` : `${diskNo}${trackNo}`;
+}

--- a/src/renderer/store/actions/PlayerActions.ts
+++ b/src/renderer/store/actions/PlayerActions.ts
@@ -5,7 +5,7 @@ import store from '../store';
 import { PlayerState } from '../reducers/player';
 
 import types from '../action-types';
-import SORT_ORDERS from '../../constants/sort-orders';
+import { createSortOrder } from '../../constants/sort-orders';
 
 import * as app from '../../lib/app';
 import Player from '../../lib/player';
@@ -69,7 +69,7 @@ export const start = async (queue?: TrackModel[], _id?: string): Promise<void> =
       const { sort, search } = library;
       newQueue = state.library.tracks.library;
 
-      newQueue = sortTracks(filterTracks(newQueue, search), SORT_ORDERS[sort.by][sort.order]);
+      newQueue = sortTracks(filterTracks(newQueue, search), createSortOrder(sort));
     }
   }
 

--- a/src/renderer/views/Library/Library.tsx
+++ b/src/renderer/views/Library/Library.tsx
@@ -5,7 +5,7 @@ import { useSelector } from 'react-redux';
 import * as ViewMessage from '../../elements/ViewMessage/ViewMessage';
 import TracksList from '../../components/TracksList/TracksList';
 import { filterTracks, sortTracks } from '../../lib/utils-library';
-import SORT_ORDERS from '../../constants/sort-orders';
+import { createSortOrder } from '../../constants/sort-orders';
 import { RootState } from '../../store/reducers';
 
 import appStyles from '../../App.module.css';
@@ -20,7 +20,7 @@ const Library: React.FC = () => {
 
     // Filter and sort TracksList
     // sorting being a costly operation, do it after filtering
-    const filteredTracks = sortTracks(filterTracks(tracks.library, search), SORT_ORDERS[sort.by][sort.order]);
+    const filteredTracks = sortTracks(filterTracks(tracks.library, search), createSortOrder(sort));
 
     return filteredTracks;
   });

--- a/src/shared/types/museeks.ts
+++ b/src/shared/types/museeks.ts
@@ -20,6 +20,7 @@ export enum SortBy {
   DURATION = 'duration',
   GENRE = 'genre',
   YEAR = 'year',
+  TRACK = 'track',
 }
 
 export enum SortOrder {

--- a/src/shared/types/museeks.ts
+++ b/src/shared/types/museeks.ts
@@ -19,6 +19,7 @@ export enum SortBy {
   TITLE = 'title',
   DURATION = 'duration',
   GENRE = 'genre',
+  YEAR = 'year',
 }
 
 export enum SortOrder {


### PR DESCRIPTION
This PR adds:

1. Year and track number display
2. Ability to sort by multiple columns

Every time the user changes sorting (asc -> dsc -> disable) of a column, it is lifted to the first in sorting order.

For example, to sort by year then by album then by track, click Track -> Album -> Year. This is the same logic as Foobar2000.