### PR TITLE
Header improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@electron/remote": "^2.0.10",
+    "@radix-ui/react-aspect-ratio": "^1.0.3",
     "@radix-ui/react-popover": "^1.0.6",
     "@radix-ui/react-slider": "^1.1.2",
     "chardet": "^1.6.0",

--- a/src/renderer/components/Cover/Cover.module.css
+++ b/src/renderer/components/Cover/Cover.module.css
@@ -1,21 +1,22 @@
 .cover {
-  width: 48px;
-  height: 48px;
-  margin-right: 10px;
-  background-position: center;
-  background-size: cover;
+  object-fit: cover;
+  width: 100%;
+  height: 100%;
   text-align: center;
-  border-style: solid;
-  border-color: var(--border-color);
-  border-width: 0 1px;
   display: flex;
   align-items: center;
   justify-content: center;
   box-sizing: content-box;
 }
 
+.empty {
+  border: solid 1px var(--border-color);
+  border-width: 0 1px;
+  box-sizing: border-box;
+}
+
 .cover__note {
   font-family: monospace; /* the sexy one */
-  font-size: 30px;
+  font-size: 28px;
   line-height: 28px;
 }

--- a/src/renderer/components/Cover/Cover.tsx
+++ b/src/renderer/components/Cover/Cover.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import * as AspectRatio from '@radix-ui/react-aspect-ratio';
 
 import { Track } from '../../../shared/types/museeks';
 
@@ -26,14 +27,24 @@ export default function Cover(props: Props) {
     const encodedCoverPath = encodeURI(coverPath)
       .replace(/'/g, "\\'")
       .replace(/"/g, '\\"');
-    const inlineStyles = { backgroundImage: `url('${encodedCoverPath}')` };
 
-    return <div className={styles.cover} style={inlineStyles} />;
+    return (
+      <AspectRatio.Root ratio={1}>
+        <img
+          src={encodedCoverPath}
+          alt="Album cover"
+          className={styles.cover}
+        />
+      </AspectRatio.Root>
+    );
   }
 
   return (
-    <div className={`${styles.cover} isEmpty`}>
-      <div className={styles.cover__note}>♪</div>
-    </div>
+    <AspectRatio.Root ratio={1}>
+      <div className={`${styles.cover} ${styles.empty}`}>
+        {/** billion dollar problem: convert emoji to text, good luck 🎵 */}
+        <div className={styles.cover__note}>♪</div>
+      </div>
+    </AspectRatio.Root>
   );
 }

--- a/src/renderer/components/DropzoneImport/DropzoneImport.module.css
+++ b/src/renderer/components/DropzoneImport/DropzoneImport.module.css
@@ -2,7 +2,7 @@
   position: fixed;
   inset: 0;
   pointer-events: none;
-  background: var(--faded);
+  background: var(--faded-bg);
   z-index: 1000;
   display: flex;
   flex-direction: column;

--- a/src/renderer/components/Header/Header.module.css
+++ b/src/renderer/components/Header/Header.module.css
@@ -17,7 +17,7 @@
   color: var(--header-color);
   padding: 0 10px;
   display: flex;
-  align-items: center;
+  align-items: stretch;
   justify-content: space-between;
   height: 50px;
   flex: 0 0 auto;
@@ -27,7 +27,6 @@
 }
 
 .header__mainControls {
-  width: 220px;
   flex: 0 0 auto;
   display: flex;
   align-items: center;
@@ -36,7 +35,7 @@
 
 .header__search {
   -webkit-app-region: no-drag;
-  width: 220px;
+  margin-left: 12px;
   flex: 0 0 auto;
   display: flex;
   justify-content: flex-end;

--- a/src/renderer/components/Header/Header.module.css
+++ b/src/renderer/components/Header/Header.module.css
@@ -12,7 +12,7 @@
 }
 
 .header {
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: solid 1px var(--border-color);
   background-color: var(--header-bg);
   color: var(--header-color);
   padding: 0 10px;
@@ -56,4 +56,13 @@
   flex: 1 1 auto;
   min-width: 0;
   max-width: 600px;
+}
+
+.header__trackProgress {
+  -webkit-app-region: no-drag;
+  z-index: 1000;
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  left: 0;
 }

--- a/src/renderer/components/PlayerControls/PlayerControls.module.css
+++ b/src/renderer/components/PlayerControls/PlayerControls.module.css
@@ -29,3 +29,8 @@
     }
   }
 }
+
+.playerOptions {
+  display: flex;
+  flex-direction: column;
+}

--- a/src/renderer/components/PlayerOptionsButtons/common.module.css
+++ b/src/renderer/components/PlayerOptionsButtons/common.module.css
@@ -2,8 +2,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 16px;
-  width: 16px;
+  height: 20px;
+  width: 20px;
 }
 
 .button {
@@ -11,7 +11,7 @@
   border: 0;
   color: inherit;
   background: transparent;
-  font-size: 18px;
+  font-size: 20px;
 
   &.active {
     .icon > svg {
@@ -21,7 +21,7 @@
 
   .icon > svg {
     fill: currentcolor;
-    width: 16px;
+    width: 18px;
     height: auto;
   }
 }

--- a/src/renderer/components/PlayingBar/PlayingBar.module.css
+++ b/src/renderer/components/PlayingBar/PlayingBar.module.css
@@ -7,7 +7,7 @@
 
 .playingBar__cover {
   flex-shrink: 0;
-  width: 49px;
+  width: 48px;
   overflow: hidden;
 }
 

--- a/src/renderer/components/PlayingBar/PlayingBar.module.css
+++ b/src/renderer/components/PlayingBar/PlayingBar.module.css
@@ -1,23 +1,19 @@
 .playingBar {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   text-align: center;
+  height: 100%;
 }
 
 .playingBar__cover {
-  width: 60px;
-  flex: 0 0 auto;
-}
-
-.playingBar__queue {
-  -webkit-app-region: no-drag;
-  width: 60px;
-  flex: 0 0 auto;
-  position: relative;
+  flex-shrink: 0;
+  width: 49px;
+  overflow: hidden;
 }
 
 .queueToggle {
+  line-height: 22px;
+  margin-left: 12px;
   color: inherit;
   border: 0;
   background: transparent;
@@ -36,4 +32,11 @@
   &[data-state='open'] {
     display: block;
   }
+}
+
+.playerOptions {
+  -webkit-app-region: no-drag;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
 }

--- a/src/renderer/components/PlayingBar/PlayingBar.tsx
+++ b/src/renderer/components/PlayingBar/PlayingBar.tsx
@@ -5,6 +5,8 @@ import Queue from '../Queue/Queue';
 import PlayingBarInfos from '../PlayingBarInfo/PlayingBarInfo';
 import Cover from '../Cover/Cover';
 import usePlayerStore from '../../stores/usePlayerStore';
+import ButtonRepeat from '../PlayerOptionsButtons/ButtonRepeat';
+import ButtonShuffle from '../PlayerOptionsButtons/ButtonShuffle';
 
 import styles from './PlayingBar.module.css';
 
@@ -28,7 +30,9 @@ export default function PlayingBar() {
         shuffle={shuffle}
         repeat={repeat}
       />
-      <div className={styles.playingBar__queue}>
+      <div className={styles.playerOptions}>
+        <ButtonRepeat />
+        <ButtonShuffle />
         <Popover.Root>
           <Popover.Trigger asChild>
             <button className={styles.queueToggle}>
@@ -38,7 +42,7 @@ export default function PlayingBar() {
           <Popover.Portal>
             <Popover.Content
               side="bottom"
-              sideOffset={8}
+              sideOffset={6}
               align="end"
               alignOffset={-10}
               avoidCollisions={false}

--- a/src/renderer/components/PlayingBarInfo/PlayingBarInfo.module.css
+++ b/src/renderer/components/PlayingBarInfo/PlayingBarInfo.module.css
@@ -4,7 +4,7 @@
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
-  padding: 0 6px;
+  padding: 0 4px;
 }
 
 .playingBar__info__metas {
@@ -38,66 +38,4 @@
   padding: 0 2px;
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
-}
-
-.playingBar__info__progress {
-  position: relative;
-}
-
-.progressTooltip {
-  position: absolute;
-  background-color: var(--background);
-  border: 1px solid var(--border-color);
-  font-size: 10px;
-  padding: 2px 5px;
-  bottom: 10px;
-  z-index: 1;
-  transform: translateX(-11px);
-
-  &::before,
-  &::after {
-    content: '';
-    position: absolute;
-    width: 0;
-    height: 0;
-    border-style: solid;
-    border-color: transparent;
-    border-bottom: 0;
-  }
-
-  /* Stroke */
-  &::before {
-    top: 16px;
-    left: 5px;
-    border-top-color: var(--border-color);
-    border-width: 6px;
-  }
-
-  /* Fill */
-  &::after {
-    top: 16px;
-    left: 6px;
-    border-top-color: var(--background);
-    border-width: 5px;
-  }
-}
-
-.progress {
-  -webkit-app-region: no-drag;
-  background-color: var(--progress-bg);
-  outline: none;
-  height: 5px;
-  margin-bottom: 0;
-  margin-top: 3px;
-  cursor: pointer;
-
-  .progressBar {
-    background-color: var(--main-color);
-    pointer-events: none;
-    transition: none;
-    transform-origin: left;
-    will-change: transform;
-    width: 100%;
-    height: 100%;
-  }
 }

--- a/src/renderer/components/PlayingBarInfo/PlayingBarInfo.module.css
+++ b/src/renderer/components/PlayingBarInfo/PlayingBarInfo.module.css
@@ -1,13 +1,17 @@
 .playingBar__info {
   flex: 1 1 auto;
   min-width: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  padding: 0 6px;
 }
 
 .playingBar__info__metas {
+  gap: 4px;
   display: flex;
-  align-items: center;
+  align-items: flex-end;
   justify-content: center;
-  margin-bottom: 4px;
 }
 
 .metas {
@@ -19,22 +23,21 @@
   text-align: center;
 }
 
-.duration {
-  flex: 0 0 auto;
-  font-size: 10px;
-  padding-right: 6px;
-  padding-left: 10px;
-  text-align: right;
-  font-variant-numeric: tabular-nums;
-  white-space: nowrap;
+.metadataTitle {
+  margin-bottom: 2px;
 }
 
-.playerOptions {
+.metadata {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.duration {
   flex: 0 0 auto;
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  padding-right: 10px;
+  font-size: 0.875rem;
+  padding: 0 2px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }
 
 .playingBar__info__progress {

--- a/src/renderer/components/PlayingBarInfo/PlayingBarInfo.tsx
+++ b/src/renderer/components/PlayingBarInfo/PlayingBarInfo.tsx
@@ -1,7 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 
-import ButtonShuffle from '../PlayerOptionsButtons/ButtonShuffle';
-import ButtonRepeat from '../PlayerOptionsButtons/ButtonRepeat';
 import * as utils from '../../lib/utils';
 import { TrackModel, Repeat } from '../../../shared/types/museeks';
 import { usePlayerAPI } from '../../stores/usePlayerStore';
@@ -115,20 +113,19 @@ export default function PlayingBarInfo(props: Props) {
   return (
     <div className={styles.playingBar__info}>
       <div className={styles.playingBar__info__metas}>
-        <div className={styles.playerOptions}>
-          <ButtonRepeat />
-          <ButtonShuffle />
-        </div>
+        <div className={styles.duration}>{utils.parseDuration(elapsed)}</div>
         <div className={styles.metas}>
-          <strong>{trackPlaying.title}</strong>
-          &nbsp;by&nbsp;
-          <strong>{trackPlaying.artist.join(', ')}</strong>
-          &nbsp;on&nbsp;
-          <strong>{trackPlaying.album}</strong>
+          <div className={`${styles.metadata} ${styles.metadataTitle}`}>
+            <strong>{trackPlaying.title}</strong>
+          </div>
+          <div className={styles.metadata}>
+            {trackPlaying.artist.join(', ')}
+            &nbsp;—&nbsp;
+            {trackPlaying.album}
+          </div>
         </div>
 
         <div className={styles.duration}>
-          {utils.parseDuration(elapsed)} /{' '}
           {utils.parseDuration(trackPlaying.duration)}
         </div>
       </div>

--- a/src/renderer/components/PlayingBarInfo/PlayingBarInfo.tsx
+++ b/src/renderer/components/PlayingBarInfo/PlayingBarInfo.tsx
@@ -1,9 +1,7 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
-
 import * as utils from '../../lib/utils';
 import { TrackModel, Repeat } from '../../../shared/types/museeks';
-import { usePlayerAPI } from '../../stores/usePlayerStore';
-import player from '../../lib/player';
+import TrackProgress from '../TrackProgress/TrackProgress';
+import usePlayingTrackCurrentTime from '../../hooks/usePlayingTrackCurrentTime';
 
 import styles from './PlayingBarInfo.module.css';
 
@@ -15,100 +13,7 @@ type Props = {
 
 export default function PlayingBarInfo(props: Props) {
   const { trackPlaying } = props;
-
-  const playingBar = useRef<HTMLDivElement>(null);
-
-  const [elapsed, setElapsed] = useState(0);
-  const [duration, setDuration] = useState<number | null>(null);
-  const [x, setX] = useState<number | null>(null);
-  const [dragging, setDragging] = useState(false);
-
-  const playerAPI = usePlayerAPI();
-
-  const tick = useCallback(() => {
-    setElapsed(player.getCurrentTime());
-  }, []);
-
-  const jumpAudioTo = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      setDragging(true);
-
-      if (playingBar.current) {
-        const parent = playingBar.current.offsetParent as HTMLDivElement;
-        const percent =
-          ((e.pageX - (playingBar.current.offsetLeft + parent.offsetLeft)) /
-            playingBar.current.offsetWidth) *
-          100;
-
-        const to = (percent * trackPlaying.duration) / 100;
-
-        playerAPI.jumpTo(to);
-      }
-    },
-    [playingBar, trackPlaying, playerAPI],
-  );
-
-  const dragOver = useCallback(
-    (e: MouseEvent) => {
-      // Check if a currentTime update is needed
-      if (dragging) {
-        if (playingBar.current) {
-          const playingBarRect = playingBar.current.getBoundingClientRect();
-
-          const barWidth = playingBar.current.offsetWidth;
-          const offsetX = Math.min(
-            Math.max(0, e.pageX - playingBarRect.left),
-            barWidth,
-          );
-
-          const percent = (offsetX / barWidth) * 100;
-
-          const to = (percent * trackPlaying.duration) / 100;
-
-          playerAPI.jumpTo(to);
-        }
-      }
-    },
-    [playingBar, dragging, trackPlaying, playerAPI],
-  );
-
-  const dragEnd = useCallback(() => {
-    setDragging(false);
-  }, []);
-
-  const showTooltip = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      const { offsetX } = e.nativeEvent;
-      const barWidth = e.currentTarget.offsetWidth;
-
-      const percent = (offsetX / barWidth) * 100;
-
-      const time = (percent * trackPlaying.duration) / 100;
-
-      setDuration(time);
-      setX(percent);
-    },
-    [trackPlaying],
-  );
-
-  const hideTooltip = useCallback(() => {
-    setDuration(null);
-    setX(null);
-  }, []);
-
-  useEffect(() => {
-    player.getAudio().addEventListener('timeupdate', tick);
-
-    window.addEventListener('mousemove', dragOver);
-    window.addEventListener('mouseup', dragEnd);
-
-    return () => {
-      player.getAudio().removeEventListener('timeupdate', tick);
-
-      window.removeEventListener('mousemove', dragOver);
-      window.removeEventListener('mouseup', dragEnd);
-    };
-  }, [dragEnd, dragOver, tick]);
+  const elapsed = usePlayingTrackCurrentTime();
 
   return (
     <div className={styles.playingBar__info}>
@@ -129,36 +34,7 @@ export default function PlayingBarInfo(props: Props) {
           {utils.parseDuration(trackPlaying.duration)}
         </div>
       </div>
-      <div className={styles.playingBar__info__progress} ref={playingBar}>
-        <div
-          className={styles.progressTooltip}
-          hidden={duration === null}
-          style={{ left: `${x}%` }}
-        >
-          {utils.parseDuration(duration)}
-        </div>
-        <div
-          className={styles.progress}
-          role="progressbar"
-          tabIndex={0}
-          onMouseDown={jumpAudioTo}
-          onMouseMove={showTooltip}
-          onMouseLeave={hideTooltip}
-        >
-          <div
-            className={styles.progressBar}
-            style={
-              elapsed / trackPlaying.duration <= 1
-                ? {
-                    transform: `scale3d(${
-                      elapsed / trackPlaying.duration
-                    }, 1, 1)`,
-                  }
-                : { display: 'none' }
-            }
-          />
-        </div>
-      </div>
+      <TrackProgress trackPlaying={trackPlaying} />
     </div>
   );
 }

--- a/src/renderer/components/Search/Search.module.css
+++ b/src/renderer/components/Search/Search.module.css
@@ -1,6 +1,8 @@
 .search__container {
   position: relative;
   width: 180px;
+  display: flex;
+  align-items: center;
 }
 
 .search__input {

--- a/src/renderer/components/TrackProgress/TrackProgress.module.css
+++ b/src/renderer/components/TrackProgress/TrackProgress.module.css
@@ -1,0 +1,66 @@
+.trackRoot {
+  -webkit-app-region: no-drag;
+  position: relative;
+  display: flex;
+  align-items: center;
+  user-select: none;
+  touch-action: none;
+  height: 5px;
+
+  /* the track progress is too close to the metadata, but using margin would
+   * push the whole section up */
+  transform: translateY(3px);
+}
+
+.trackProgress {
+  display: block;
+  width: 100%;
+  height: 100%;
+  background-color: var(--progress-bg);
+  box-shadow: inset 0 0 0 1px var(--border-color);
+}
+
+.trackRange {
+  position: absolute;
+  height: 100%;
+  background-color: var(--main-color);
+  box-shadow: inset 0 0 0 1px rgba(0 0 0 / 0.2);
+}
+
+.progressTooltip {
+  position: absolute;
+  background-color: var(--background);
+  border: 1px solid var(--border-color);
+  font-size: 10px;
+  padding: 2px 5px;
+  bottom: 10px;
+  z-index: 1;
+  transform: translateX(-11px);
+
+  &::before,
+  &::after {
+    content: '';
+    position: absolute;
+    width: 0;
+    height: 0;
+    border-style: solid;
+    border-color: transparent;
+    border-bottom: 0;
+  }
+
+  /* Stroke */
+  &::before {
+    top: 16px;
+    left: 5px;
+    border-top-color: var(--border-color);
+    border-width: 6px;
+  }
+
+  /* Fill */
+  &::after {
+    top: 15px;
+    left: 6px;
+    border-top-color: var(--background);
+    border-width: 5px;
+  }
+}

--- a/src/renderer/components/TrackProgress/TrackProgress.tsx
+++ b/src/renderer/components/TrackProgress/TrackProgress.tsx
@@ -1,0 +1,80 @@
+import { useCallback, useState } from 'react';
+import * as Slider from '@radix-ui/react-slider';
+
+import { usePlayerAPI } from '../../stores/usePlayerStore';
+import { TrackModel } from '../../../shared/types/museeks';
+import usePlayingTrackCurrentTime from '../../hooks/usePlayingTrackCurrentTime';
+import { parseDuration } from '../../lib/utils';
+
+import styles from './TrackProgress.module.css';
+
+type Props = {
+  trackPlaying: TrackModel;
+};
+
+export default function TrackProgress(props: Props) {
+  const { trackPlaying } = props;
+
+  const elapsed = usePlayingTrackCurrentTime();
+  const playerAPI = usePlayerAPI();
+
+  const jumpAudioTo = useCallback(
+    (values: number[]) => {
+      const [to] = values;
+
+      playerAPI.jumpTo(to);
+    },
+    [playerAPI],
+  );
+
+  const [tooltipTargetTime, setTooltipTargetTime] = useState<null | number>(
+    null,
+  );
+  const [tooltipX, setTooltipX] = useState<null | number>(null);
+
+  const showTooltip = useCallback(
+    (e: React.MouseEvent<HTMLElement>) => {
+      const { offsetX } = e.nativeEvent;
+      const barWidth = e.currentTarget.offsetWidth;
+
+      const percent = (offsetX / barWidth) * 100;
+
+      const time = (percent * trackPlaying.duration) / 100;
+
+      setTooltipTargetTime(time);
+      setTooltipX(percent);
+    },
+    [trackPlaying],
+  );
+
+  const hideTooltip = useCallback(() => {
+    setTooltipTargetTime(null);
+    setTooltipX(null);
+  }, []);
+
+  return (
+    <Slider.Root
+      min={0}
+      max={trackPlaying.duration}
+      step={1}
+      value={[elapsed]}
+      onValueChange={jumpAudioTo}
+      className={styles.trackRoot}
+      onMouseMove={showTooltip}
+      onMouseLeave={hideTooltip}
+    >
+      <Slider.Track className={styles.trackProgress}>
+        <Slider.Range className={styles.trackRange} />
+        {tooltipX !== null && (
+          <div
+            className={styles.progressTooltip}
+            style={{ left: `${tooltipX}%` }}
+          >
+            {parseDuration(tooltipTargetTime)}
+          </div>
+        )}
+      </Slider.Track>
+      <Slider.Thumb />
+    </Slider.Root>
+  );
+}

--- a/src/renderer/components/TracksList/TracksList.tsx
+++ b/src/renderer/components/TracksList/TracksList.tsx
@@ -494,10 +494,10 @@ export default function TracksList(props: Props) {
         itemContent={(index, track) => {
           return (
             <TrackRow
-              selected={selected.includes(track._id)}
-              track={tracks[index]}
-              isPlaying={trackPlayingId === track._id}
+              track={track}
               index={index}
+              selected={selected.includes(track._id)}
+              isPlaying={trackPlayingId === track._id}
               onMouseDown={selectTrack}
               onClick={selectTrackClick}
               onContextMenu={showContextMenu}

--- a/src/renderer/components/TracksListHeaderCell/TracksListHeaderCell.module.css
+++ b/src/renderer/components/TracksListHeaderCell/TracksListHeaderCell.module.css
@@ -1,5 +1,5 @@
 .trackCellHeader {
-  font-weight: 700;
+  font-weight: var(--bold);
   appearance: none;
   border: 0;
   background: transparent;

--- a/src/renderer/components/VolumeControl/VolumeControl.module.css
+++ b/src/renderer/components/VolumeControl/VolumeControl.module.css
@@ -3,7 +3,7 @@
 }
 
 .volumeControl {
-  -webkit-app-region: nodrag;
+  -webkit-app-region: no-drag;
   background-color: var(--header-bg);
   position: absolute;
   z-index: 10;

--- a/src/renderer/hooks/usePlayingTrack.ts
+++ b/src/renderer/hooks/usePlayingTrack.ts
@@ -1,9 +1,10 @@
+import { TrackModel } from '../../shared/types/museeks';
 import usePlayerStore from '../stores/usePlayerStore';
 
-export default function useTrackPlayingID(): string | null {
+export default function usePlayingTrack(): TrackModel | null {
   return usePlayerStore((state) => {
     if (state.queue.length > 0 && state.queueCursor !== null) {
-      return state.queue[state.queueCursor]._id;
+      return state.queue[state.queueCursor];
     }
 
     return null;

--- a/src/renderer/hooks/usePlayingTrackCurrentTime.ts
+++ b/src/renderer/hooks/usePlayingTrackCurrentTime.ts
@@ -1,0 +1,24 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import player from '../lib/player';
+
+/**
+ * Returns the current track elapsed time
+ */
+export default function usePlayingTrackCurrentTime(): number {
+  const [currentTime, setCurrentTime] = useState(player.getCurrentTime());
+
+  const tick = useCallback(() => {
+    setCurrentTime(player.getCurrentTime());
+  }, [setCurrentTime]);
+
+  useEffect(() => {
+    player.getAudio().addEventListener('timeupdate', tick);
+
+    return () => {
+      player.getAudio().removeEventListener('timeupdate', tick);
+    };
+  }, [tick]);
+
+  return currentTime;
+}

--- a/src/renderer/hooks/usePlayingTrackID.ts
+++ b/src/renderer/hooks/usePlayingTrackID.ts
@@ -1,0 +1,5 @@
+import usePlayingTrack from './usePlayingTrack';
+
+export default function usePlayingTrackID(): string | null {
+  return usePlayingTrack()?._id ?? null;
+}

--- a/src/renderer/styles/general.module.css
+++ b/src/renderer/styles/general.module.css
@@ -3,6 +3,7 @@
   --main-color: #459ce7;
   --link-color: #459ce7;
   --link-color-hover: #52afff;
+  --bold: 600;
 }
 
 *,
@@ -22,7 +23,8 @@ html {
 
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+    Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   color: var(--text);
   font-size: 12px;
   user-select: none;
@@ -51,6 +53,10 @@ input {
 
 p {
   line-height: 1.3;
+}
+
+strong {
+  font-weight: var(--bold);
 }
 
 /* App wrapper */

--- a/src/renderer/views/Library/Library.tsx
+++ b/src/renderer/views/Library/Library.tsx
@@ -7,12 +7,12 @@ import appStyles from '../Root.module.css';
 import { LibraryLoaderResponse, RootLoaderResponse } from '../router';
 import useFilteredTracks from '../../hooks/useFilteredTracks';
 import useLibraryStore from '../../stores/useLibraryStore';
-import useTrackPlayingID from '../../hooks/useTrackPlayingID';
+import usePlayingTrackID from '../../hooks/usePlayingTrackID';
 
 import styles from './Library.module.css';
 
 export default function Library() {
-  const trackPlayingId = useTrackPlayingID();
+  const trackPlayingId = usePlayingTrackID();
   const refreshing = useLibraryStore((state) => state.refreshing);
   const search = useLibraryStore((state) => state.search);
 

--- a/src/renderer/views/Playlists/Playlist.tsx
+++ b/src/renderer/views/Playlists/Playlist.tsx
@@ -7,13 +7,13 @@ import PlaylistsAPI from '../../stores/PlaylistsAPI';
 import { filterTracks } from '../../lib/utils-library';
 import { PlaylistLoaderResponse } from '../router';
 import useLibraryStore from '../../stores/useLibraryStore';
-import useTrackPlayingID from '../../hooks/useTrackPlayingID';
+import usePlayingTrackID from '../../hooks/usePlayingTrackID';
 
 export default function Playlist() {
   const { playlists, playlistTracks } =
     useLoaderData() as PlaylistLoaderResponse;
   const { playlistId } = useParams();
-  const trackPlayingId = useTrackPlayingID();
+  const trackPlayingId = usePlayingTrackID();
 
   const search = useLibraryStore((state) => state.search);
   const filteredTracks = useMemo(

--- a/src/shared/themes/dark-legacy.json
+++ b/src/shared/themes/dark-legacy.json
@@ -6,7 +6,7 @@
     "--color-scheme": "dark",
     "--text": "#EEEEEE",
     "--background": "#23292B",
-    "--faded": "rgba(0, 0, 0, 0.8)",
+    "--faded-bg": "rgba(0, 0, 0, 0.8)",
 
     "--border-color": "#1F1F1F",
     "--border-radius": "2px",

--- a/src/shared/themes/dark.json
+++ b/src/shared/themes/dark.json
@@ -6,7 +6,7 @@
     "--color-scheme": "dark",
     "--text": "#efefef",
     "--background": "hsl(216, 0%, 9.5%)",
-    "--faded": "rgba(0, 0, 0, 0.8)",
+    "--faded-bg": "rgba(0, 0, 0, 0.8)",
 
     "--border-color": "#0a0a0a",
     "--border-radius": "2px",

--- a/src/shared/themes/light.json
+++ b/src/shared/themes/light.json
@@ -6,7 +6,7 @@
     "--color-scheme": "light",
     "--text": "#333333",
     "--background": "white",
-    "--faded": "rgba(255, 255, 255, 0.9)",
+    "--faded-bg": "rgba(255, 255, 255, 0.9)",
 
     "--border-color": "#D2D2D2",
     "--border-radius": "2px",

--- a/yarn.lock
+++ b/yarn.lock
@@ -664,6 +664,14 @@
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-primitive" "1.0.3"
 
+"@radix-ui/react-aspect-ratio@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-1.0.3.tgz#d1a15d6953203e6fd7f5b569fae77c88c1880125"
+  integrity sha512-fXR5kbMan9oQqMuacfzlGG/SQMcmMlZ4wrvpckv8SgUulD0MMpspxJrxg/Gp/ISV3JfV1AeSWTYK9GvxA4ySwA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-primitive" "1.0.3"
+
 "@radix-ui/react-collection@1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-collection/-/react-collection-1.0.3.tgz#9595a66e09026187524a36c6e7e9c7d286469159"


### PR DESCRIPTION
A bunch of stuff, but basically: 

- Bigger horizontal space for tracks metadata
- Title & Artists + Album on two line

Still to think about:
- Re-think volume?
- Fix the muted weird behavior?
- Not satisfied with progress text `(00:00 / 00:00)`

### Before 
<img width="1012" alt="Screenshot 2023-06-29 at 18 49 35" src="https://github.com/martpie/museeks/assets/1311607/29ef77eb-57fc-442c-9c15-6dec38d45a0e">

### After 

<img width="1012" alt="Screenshot 2023-06-29 at 18 50 32" src="https://github.com/martpie/museeks/assets/1311607/8077f086-6dec-452d-8f65-0bce9c28a86f">
