### PR TITLE
Replace "macos" with "app-close" plugin

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -20,6 +20,7 @@ async fn main() {
 
     tauri::Builder::default()
         // Custom integrations
+        .plugin(plugins::app_close::init())
         .plugin(plugins::app_menu::init())
         .plugin(plugins::config::init())
         .plugin(plugins::cover::init())
@@ -28,7 +29,6 @@ async fn main() {
         .plugin(plugins::default_view::init())
         .plugin(plugins::shell_extension::init())
         .plugin(plugins::sleepblocker::init())
-        .plugin(plugins::macos::init())
         // Tauri integrations with the Operating System
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_os::init())

--- a/src-tauri/src/plugins/app_close.rs
+++ b/src-tauri/src/plugins/app_close.rs
@@ -1,16 +1,18 @@
 use tauri::plugin::{Builder, TauriPlugin};
-use tauri::{Manager, Runtime};
+use tauri::Runtime;
 
 /**
  * Plugin in charge on making sure closing the app does not stop the audio
  */
 pub fn init<R: Runtime>() -> TauriPlugin<R> {
-    Builder::<R>::new("sleepblocker")
+    Builder::<R>::new("app-close")
         .on_window_ready(|win| {
             // Prevent macOS to kill the player when closing the main window. Instead,
             // the window should be hidden and re-shown when invoking it again.
             #[cfg(target_os = "macos")]
             {
+                use tauri::Manager as _; // Suppress warning about unused import.
+
                 // Weird, should "win" be a reference instead maybe?
                 let window = win.clone();
 
@@ -22,6 +24,9 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
                     _ => {}
                 });
             }
+            // TODO: Implement the same for Windows and Linux if needed.
+            #[cfg(not(target_os = "macos"))]
+            drop(win); // Suppress warning about unused variable.
         })
         .build()
 }

--- a/src-tauri/src/plugins/mod.rs
+++ b/src-tauri/src/plugins/mod.rs
@@ -9,6 +9,7 @@ pub mod debug;
 /**
  * Core features
  */
+pub mod app_close;
 pub mod app_menu;
 pub mod cover;
 pub mod shell_extension;
@@ -24,8 +25,3 @@ pub mod database;
  */
 pub mod default_view;
 pub mod sleepblocker;
-
-/**
- * OS-specific plugins
- */
-pub mod macos;


### PR DESCRIPTION
Fixes the build on Linux (and probably Windows).