### PR TITLE
Replace home-config with directories+toml

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -608,7 +608,7 @@ checksum = "13c96879fa66046a8d550de9c52f93fa99feea4b24e81917f883c39b5eb11f54"
 dependencies = [
  "attribute-derive",
  "manyhow",
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
  "quote-use",
@@ -639,7 +639,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4918709cc4dd777ad2b6303ed03cb37f3ca0ccede8c1b0d28ac6db8f4710e0"
 dependencies = [
  "once_cell",
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
  "syn 2.0.52",
@@ -811,7 +811,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a969e13a7589e9e3e4207e153bae624ade2b5622fb4684a4923b23ec3d57719"
 dependencies = [
  "serde",
- "toml 0.8.2",
+ "toml 0.8.11",
 ]
 
 [[package]]
@@ -1333,12 +1333,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "4.0.0"
+name = "directories"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
 dependencies = [
- "dirs-sys 0.3.7",
+ "dirs-sys",
 ]
 
 [[package]]
@@ -1347,7 +1347,7 @@ version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "dirs-sys 0.4.1",
+ "dirs-sys",
 ]
 
 [[package]]
@@ -1358,17 +1358,6 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -1565,7 +1554,7 @@ dependencies = [
  "cc",
  "memchr",
  "rustc_version",
- "toml 0.8.2",
+ "toml 0.8.11",
  "vswhom",
  "winreg 0.51.0",
 ]
@@ -2236,7 +2225,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bb0228f477c0900c880fd78c8759b95c7636dbd7842707f49e132378aa2acdc"
 dependencies = [
  "heck",
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 2.0.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -2427,17 +2416,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
-]
-
-[[package]]
-name = "home-config"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27825a5c636b5efd43d1b76065198d4e7927951593202c88764bfd9693cf4cf0"
-dependencies = [
- "dirs 4.0.0",
- "serde",
- "toml 0.5.11",
 ]
 
 [[package]]
@@ -3138,9 +3116,9 @@ dependencies = [
  "base64 0.22.0",
  "bonsaidb",
  "dbus",
- "dirs 5.0.1",
+ "directories",
+ "dirs",
  "futures",
- "home-config",
  "lofty",
  "log",
  "memoize",
@@ -3160,6 +3138,7 @@ dependencies = [
  "tauri-plugin-window-state",
  "thiserror",
  "tokio",
+ "toml 0.8.11",
  "ts-rs",
  "uuid",
  "walkdir",
@@ -3875,11 +3854,10 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "2.0.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b00f26d3400549137f92511a46ac1cd8ce37cb5598a96d382381458b992a5d24"
+checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
 dependencies = [
- "toml_datetime",
  "toml_edit 0.20.2",
 ]
 
@@ -4976,7 +4954,7 @@ dependencies = [
  "cfg-expr",
  "heck",
  "pkg-config",
- "toml 0.8.2",
+ "toml 0.8.11",
  "version-compare",
 ]
 
@@ -5113,7 +5091,7 @@ dependencies = [
  "tauri-codegen",
  "tauri-utils",
  "tauri-winres",
- "toml 0.8.2",
+ "toml 0.8.11",
  "walkdir",
 ]
 
@@ -5171,7 +5149,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tauri-utils",
- "toml 0.8.2",
+ "toml 0.8.11",
  "walkdir",
 ]
 
@@ -5394,7 +5372,7 @@ dependencies = [
  "serde_with",
  "swift-rs",
  "thiserror",
- "toml 0.8.2",
+ "toml 0.8.11",
  "url",
  "urlpattern",
  "walkdir",
@@ -5595,15 +5573,6 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
@@ -5616,21 +5585,21 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.2"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
+checksum = "af06656561d28735e9c1cd63dfd57132c8155426aa6af24f36a00a351f88c48e"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.20.2",
+ "toml_edit 0.22.7",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 dependencies = [
  "serde",
 ]
@@ -5645,7 +5614,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
 ]
 
 [[package]]
@@ -5655,10 +5624,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
  "indexmap 2.2.4",
+ "toml_datetime",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18769cd1cec395d70860ceb4d932812a0b4d06b1a4bb336745a4d21b9496e992"
+dependencies = [
+ "indexmap 2.2.4",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.6.5",
 ]
 
 [[package]]
@@ -6657,6 +6637,15 @@ name = "winnow"
 version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
 dependencies = [
  "memchr",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,7 +27,7 @@ base64 = "0.22.0"
 bonsaidb = { version = "0.5.0", features = ["local", "async"] }
 dirs = "5.0.1"
 futures = "0.3.30"
-home-config = { version = "0.6.0", features = ["toml"] }
+directories = "5.0.1"
 log = "0.4.21"
 lofty = "0.18.2"
 memoize = "0.4.2"
@@ -38,6 +38,7 @@ serde = { version = "1.0.197", features = ["derive"] }
 strum = { version = "0.26.2", features = ["derive"] }
 thiserror = "1.0.58"
 tokio = { version = "1.36.0", features = ["macros"] }
+toml = { version = "0.8.11", default-features = false, features = ["parse"] }
 ts-rs = "7.1.1"
 uuid = { version = "1.7.0", features = ["v3", "v4", "fast-rng"] }
 walkdir = "2.5.0"

--- a/src-tauri/src/plugins/database.rs
+++ b/src-tauri/src/plugins/database.rs
@@ -1,3 +1,4 @@
+use anyhow::anyhow;
 use bonsaidb::core::connection::{AsyncCollection, AsyncConnection, AsyncStorageConnection};
 use bonsaidb::core::document::OwnedDocument;
 use bonsaidb::core::schema::{Collection, SerializedCollection};
@@ -20,7 +21,7 @@ use uuid::Uuid;
 
 use crate::libs::error::{AnyResult, MuseeksError};
 use crate::libs::events::IPCEvent;
-use crate::libs::utils::{get_app_storage_dir, scan_dirs, TimeLogger};
+use crate::libs::utils::{app_data_dir, scan_dirs, TimeLogger};
 
 const INSERTION_BATCH: usize = 200;
 
@@ -538,8 +539,8 @@ async fn reset(db: State<'_, DB>) -> AnyResult<()> {
  * Doc: https://github.com/khonsulabs/bonsaidb/blob/main/examples/basic-local/examples/basic-local-multidb.rs
  */
 pub async fn setup() -> AnyResult<DB> {
-    let conf_path = get_app_storage_dir();
-    let storage_configuration = StorageConfiguration::new(conf_path.join("main.bonsaidb"))
+    let app_data_path = app_data_dir().ok_or_else(|| anyhow!("no app data directory"))?;
+    let storage_configuration = StorageConfiguration::new(app_data_path.join("main.bonsaidb"))
         .with_schema::<Track>()?
         .with_schema::<Playlist>()?;
 

--- a/src-tauri/src/plugins/default_view.rs
+++ b/src-tauri/src/plugins/default_view.rs
@@ -22,7 +22,7 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
             if window.label().eq("main") {
                 let config_manager = window.state::<ConfigManager>();
                 let mut url = window.url();
-                let default_view = config_manager.get().default_view;
+                let default_view = config_manager.read().default_view;
 
                 let fragment = match default_view {
                     DefaultView::Library => "/library",


### PR DESCRIPTION
Instead of creating config/data directories manually the [directories](https://crates.io/crates/directories) crate should be used for platform-independent standard locations.

On Linux the files land in `{HOME}/.config/io.museeks.app/` (local config, also used by Tauri) and `{HOME}/.local/share/io.museeks.app/` (local data).

Please adjust as desired.