### PR TITLE
[Tauri][wip] Fix theme integration

### DIFF
--- a/src-tauri/src/libs/events.rs
+++ b/src-tauri/src/libs/events.rs
@@ -12,11 +12,12 @@ pub enum IPCEvent<'a> {
     PlaybackPrevious,
     PlaybackNext,
     PlaybackTrackChange,
-    // Scan-related events
-    LibraryScanProgress,
     // Menu-related events
     GoToLibrary,
     GoToPlaylists,
     GoToSettings,
     JumpToPlayingTrack,
+    // Misc
+    LibraryScanProgress,
+    ThemeUpdate,
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -38,6 +38,7 @@ async fn main() {
         .plugin(plugins::default_view::init())
         .plugin(plugins::shell_extension::init())
         .plugin(plugins::sleepblocker::init())
+        .plugin(plugins::theme::init())
         // Tauri integrations with the Operating System
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_os::init())

--- a/src-tauri/src/plugins/config.rs
+++ b/src-tauri/src/plugins/config.rs
@@ -9,6 +9,8 @@ use tauri::plugin::{Builder, TauriPlugin};
 use tauri::{Manager, Runtime, State};
 use ts_rs::TS;
 
+use super::theme::SYSTEM_THEME_ID;
+
 #[derive(Serialize, Deserialize, Debug, Clone, TS)]
 #[ts(export, export_to = "../src/generated/typings/Repeat.ts")]
 pub enum Repeat {
@@ -65,7 +67,7 @@ pub struct Config {
 impl Config {
     pub fn default() -> Self {
         Config {
-            theme: "__system".to_owned(),
+            theme: SYSTEM_THEME_ID.to_owned(),
             audio_volume: 1.0,
             audio_playback_rate: 1.0,
             audio_output_device: "default".to_owned(),

--- a/src-tauri/src/plugins/mod.rs
+++ b/src-tauri/src/plugins/mod.rs
@@ -13,6 +13,7 @@ pub mod app_close;
 pub mod app_menu;
 pub mod cover;
 pub mod shell_extension;
+pub mod theme;
 
 /**
  * Stores

--- a/src-tauri/src/plugins/theme.rs
+++ b/src-tauri/src/plugins/theme.rs
@@ -1,0 +1,39 @@
+use log::info;
+use tauri::plugin::{Builder, TauriPlugin};
+use tauri::{Manager, Runtime, WindowEvent};
+
+use crate::libs::events::IPCEvent;
+
+pub const SYSTEM_THEME_ID: &str = "__system";
+
+/**
+ * This plugin listens to system-wide theme changes and update the window
+ * theme accordingly + do the same based on potential user overrides of the
+ * theme setting.
+ */
+pub fn init<R: Runtime>() -> TauriPlugin<R> {
+    Builder::<R>::new("theme")
+        .on_window_ready(|win| {
+            // Weird, should "win" be a reference instead maybe?
+            let window = win.clone();
+
+            win.on_window_event(move |event| match event {
+                WindowEvent::ThemeChanged(theme) => {
+                    let theme_id = match theme {
+                        tauri::Theme::Light => "light",
+                        tauri::Theme::Dark => "dark",
+                        _ => unreachable!(),
+                    };
+
+                    // TODO check from the config if the theme is set to system
+                    // otherwise, we should not update the theme
+                    info!("System theme has changed to {:?}", theme);
+                    window
+                        .emit(IPCEvent::ThemeUpdate.as_ref(), theme_id)
+                        .unwrap();
+                }
+                _ => {}
+            })
+        })
+        .build()
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,8 +14,6 @@
         "label": "main",
         "title": "Museeks",
         "visible": false,
-        "hiddenTitle": true,
-        "titleBarStyle": "Overlay",
         "height": 550,
         "minHeight": 550,
         "width": 900,

--- a/src/components/TrackProgress/TrackProgress.module.css
+++ b/src/components/TrackProgress/TrackProgress.module.css
@@ -1,5 +1,6 @@
 .trackRoot {
-  --progress-height: 7px;
+  --progress-height: 5px;
+  --progress-border-width: 1px;
 
   position: relative;
   display: flex;
@@ -19,14 +20,15 @@
   width: 100%;
   height: 100%;
   background-color: var(--header-bg);
-  border: solid 1px var(--border-color);
+  border: solid var(--progress-border-width) var(--border-color);
 }
 
 .trackRange {
   position: absolute;
-  height: 100%;
+  top: -1px;
+  bottom: -1px;
   background-color: var(--main-color);
-  box-shadow: inset 0 0 0 1px rgba(0 0 0 / 0.2);
+  box-shadow: inset 0 0 0 1px rgba(0 0 0 / 0.3);
 }
 
 .progressTooltip {


### PR DESCRIPTION
do not merge. not ready. code sucks. the whole process sucks. I have to draw a flow chart from scratch.

I need to move that code to a single-direction-data-flow.

What we need to reimplement:

- [ ] [Museeks 0.13 behavior](https://github.com/martpie/museeks/blob/277203176555331f88462d4ba2cf88d07d436ddc/src/main/modules/NativeThemeModule.ts#L102), but for Tauri
  - [x] "System" theme
    - [x] Window theme is correctly set (already done by Tauri, when `theme` is `None`)
      - [ ] **[hard]** While making explicit light/dark initial window theme work
    - [x] Update theme based on the `ThemeChanged` event
  - [ ] "Dark" or "Light" theme
    - [ ]  Set dark/light window theme on startup
    - [ ] Set dark/light app content theme on startup
    - [ ] **[hard]** Update window theme at runtime when user selects a new theme