### PR TITLE
feat: add Simplified Chinese (zh-CN) translation

### DIFF
--- a/src/translations/languages.ts
+++ b/src/translations/languages.ts
@@ -23,6 +23,12 @@ export const NON_DEFAULT_LANGUAGE = [
     code: 'ru',
     contributors: ['ildar nizamov'],
   },
+  {
+    label: '简体中文',
+    englishLabel: 'Simplified Chinese',
+    code: 'zh-CN',
+    contributors: ['Tang Shijian'],
+  },
 ];
 
 export const ALL_LANGUAGES = [DEFAULT_LANGUAGE, ...NON_DEFAULT_LANGUAGE];

--- a/src/translations/zh-CN.po
+++ b/src/translations/zh-CN.po
@@ -1,0 +1,607 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2025-08-11 11:27+0800\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: zh-CN\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#: src/components/ButtonRepeat.tsx:18
+msgid "Repeat"
+msgstr "重复"
+
+#: src/components/ButtonShuffle.tsx:12
+msgid "Shuffle"
+msgstr "随机播放"
+
+#: src/components/Cover.tsx:33
+msgid "Album cover"
+msgstr "专辑封面"
+
+#: src/components/DropzoneImport.tsx:52
+msgid "{skippedItemsCount, plural, one {# invalid item ignored} other {# invalid items ignored}}"
+msgstr "{skippedItemsCount, plural, one {# 个无效项目已忽略} other {# 个无效项目已忽略}}"
+
+#. placeholder {0}: folders.length
+#: src/components/DropzoneImport.tsx:63
+msgid "{0, plural, one {# folder added to the library} other {# folders added to the library}}"
+msgstr "{0, plural, one {# 个文件夹已添加到音乐库} other {# 个文件夹已添加到音乐库}}"
+
+#: src/components/DropzoneImport.tsx:100
+msgid "Add music to the library"
+msgstr "添加音乐到音乐库"
+
+#: src/components/DropzoneImport.tsx:101
+msgid "Drop folders anywhere"
+msgstr "将文件夹拖放到任意位置"
+
+#: src/components/Footer.tsx:21
+#: src/routes/settings.tsx:42
+msgid "Library"
+msgstr "音乐库"
+
+#: src/components/Footer.tsx:31
+#: src/routes/artists.tsx:52
+msgid "Artists"
+msgstr "艺术家"
+
+#: src/components/Footer.tsx:41
+#: src/routes/playlists.tsx:165
+#: src/routes/settings.ui.tsx:129
+msgid "Playlists"
+msgstr "播放列表"
+
+#: src/components/Footer.tsx:51
+msgid "Settings"
+msgstr "设置"
+
+#: src/components/Footer.tsx:83
+msgid "scanning tracks..."
+msgstr "正在扫描音轨..."
+
+#: src/components/GlobalErrors.tsx:32
+msgid "Something wrong happened: {errorMessage}"
+msgstr "发生了错误：{errorMessage}"
+
+#: src/components/GlobalErrors.tsx:46
+msgid "how?"
+msgstr "怎么回事？"
+
+#. placeholder {0}: location.pathname
+#: src/components/GlobalErrors.tsx:49
+msgid "View not found ({0}). How did you get here?"
+msgstr "页面未找到 ({0})。您是怎么到达这里的？"
+
+#: src/components/GlobalErrors.tsx:61
+msgid "If it happens again, please <0>report an issue</0>"
+msgstr "如果再次发生，请<0>报告问题</0>"
+
+#: src/components/Header.tsx:34
+msgid "Queue"
+msgstr "播放队列"
+
+#: src/components/PlayerControls.tsx:19
+msgid "Previous"
+msgstr "上一首"
+
+#: src/components/PlayerControls.tsx:26
+msgid "Pause"
+msgstr "暂停"
+
+#: src/components/PlayerControls.tsx:26
+msgid "Play"
+msgstr "播放"
+
+#: src/components/PlayerControls.tsx:37
+msgid "Next"
+msgstr "下一首"
+
+#: src/components/QueueEmpty.tsx:8
+msgid "Queue is empty"
+msgstr "播放队列为空"
+
+#: src/components/QueueList.tsx:81
+msgid "clear queue"
+msgstr "清空队列"
+
+#: src/components/QueueList.tsx:107
+msgid "see more"
+msgstr "查看更多"
+
+#: src/components/Search.tsx:43
+msgid "search..."
+msgstr "搜索..."
+
+#: src/components/SideNavLink.tsx:61
+msgid "Rename"
+msgstr "重命名"
+
+#: src/components/TrackList.tsx:242
+msgid "Create new playlist..."
+msgstr "创建新播放列表..."
+
+#: src/components/TrackList.tsx:245
+#: src/routes/playlists.tsx:63
+msgid "New playlist"
+msgstr "新播放列表"
+
+#: src/components/TrackList.tsx:258
+msgid "No playlists"
+msgstr "没有播放列表"
+
+#. placeholder {0}: selectedTracks.size
+#. placeholder {1}: playlist.name
+#: src/components/TrackList.tsx:273
+msgid "{0} track(s) were added to \"{1}\""
+msgstr "{0} 首音轨已添加到 \"{1}\""
+
+#: src/components/TrackList.tsx:290
+msgid "{selectedCount, plural, one {# track selected} other {# tracks selected}}"
+msgstr "{selectedCount, plural, one {# 首音轨已选择} other {# 首音轨已选择}}"
+
+#: src/components/TrackList.tsx:302
+msgid "Add to queue"
+msgstr "添加到队列"
+
+#: src/components/TrackList.tsx:308
+msgid "Play next"
+msgstr "下一个播放"
+
+#: src/components/TrackList.tsx:318
+msgid "Add to playlist"
+msgstr "添加到播放列表"
+
+#: src/components/TrackList.tsx:328
+msgid "Search for \"{item}\""
+msgstr "搜索 \"{item}\""
+
+#: src/components/TrackList.tsx:341
+msgid "Copy \"{item}\""
+msgstr "复制 \"{item}\""
+
+#: src/components/TrackList.tsx:365
+msgid "Edit track"
+msgstr "编辑音轨"
+
+#: src/components/TrackList.tsx:375
+msgid "Show in file manager"
+msgstr "在文件管理器中显示"
+
+#: src/components/TrackList.tsx:381
+msgid "Remove from library"
+msgstr "从音乐库中移除"
+
+#. placeholder {0}: selectedTracks.size
+#: src/components/TrackList.tsx:384
+msgid "Are you sure you want to remove {0} track(s) from your library?"
+msgstr "您确定要从音乐库中移除 {0} 首音轨吗？"
+
+#: src/components/TrackList.tsx:386
+msgid "Remove tracks"
+msgstr "移除音轨"
+
+#: src/components/TrackList.tsx:388
+#: src/routes/settings.library.tsx:98
+#: src/routes/settings.library.tsx:143
+#: src/routes/tracks.$trackID.tsx:246
+msgid "Cancel"
+msgstr "取消"
+
+#: src/components/TrackList.tsx:389
+#: src/routes/settings.library.tsx:61
+msgid "Remove"
+msgstr "移除"
+
+#. placeholder {0}: props.count
+#. placeholder {0}: tracks.length
+#: src/components/TrackListGrouped.tsx:102
+#: src/components/TrackListStatus.tsx:11
+msgid "{0, plural, one {# track} other {# tracks}}"
+msgstr "{0, plural, one {# 首音轨} other {# 首音轨}}"
+
+#: src/components/TrackListHeader.tsx:46
+#: src/routes/tracks.$trackID.tsx:87
+msgid "Title"
+msgstr "标题"
+
+#: src/components/TrackListHeader.tsx:53
+#: src/routes/tracks.$trackID.tsx:230
+msgid "Duration"
+msgstr "时长"
+
+#: src/components/TrackListHeader.tsx:60
+msgid "Artist"
+msgstr "艺术家"
+
+#: src/components/TrackListHeader.tsx:67
+#: src/routes/tracks.$trackID.tsx:98
+msgid "Album"
+msgstr "专辑"
+
+#: src/components/TrackListHeader.tsx:74
+#: src/routes/tracks.$trackID.tsx:138
+msgid "Genre"
+msgstr "流派"
+
+#: src/components/TrackListStates.tsx:25
+msgid "Loading library..."
+msgstr "正在加载音乐库..."
+
+#: src/components/TrackListStates.tsx:36
+msgid "Your library is being scanned"
+msgstr "您的音乐库正在被扫描"
+
+#: src/components/TrackListStates.tsx:39
+msgid "hold on..."
+msgstr "请稍候..."
+
+#: src/components/TrackListStates.tsx:50
+msgid "There is no music in your library"
+msgstr "您的音乐库中没有音乐"
+
+#: src/components/TrackListStates.tsx:53
+msgid "you can <0>add your music here</0>"
+msgstr "您可以<0>在这里添加音乐</0>"
+
+#: src/components/TrackListStates.tsx:69
+#: src/routes/playlists.$playlistID.tsx:108
+msgid "Your search returned no results"
+msgstr "您的搜索没有返回结果"
+
+#: src/components/VolumeControl.tsx:73
+#: src/components/VolumeControl.tsx:93
+msgid "Volume"
+msgstr "音量"
+
+#: src/routes/playlists.$playlistID.tsx:76
+msgid "Remove from playlist"
+msgstr "从播放列表中移除"
+
+#: src/routes/playlists.$playlistID.tsx:92
+#: src/routes/playlists.$playlistID.tsx:119
+msgid "Empty playlist"
+msgstr "空播放列表"
+
+#: src/routes/playlists.$playlistID.tsx:95
+#: src/routes/playlists.$playlistID.tsx:122
+msgid "You can add tracks from the <0>library view</0>"
+msgstr "您可以从<0>音乐库视图</0>添加音轨"
+
+#: src/routes/playlists.tsx:93
+msgid "Delete"
+msgstr "删除"
+
+#: src/routes/playlists.tsx:102
+msgid "Duplicate"
+msgstr "复制"
+
+#: src/routes/playlists.tsx:110
+msgid "Export"
+msgstr "导出"
+
+#: src/routes/playlists.tsx:140
+msgid "You haven't created any playlist yet"
+msgstr "您还没有创建任何播放列表"
+
+#: src/routes/playlists.tsx:144
+msgid "create one now"
+msgstr "现在创建一个"
+
+#: src/routes/playlists.tsx:153
+msgid "No playlist selected"
+msgstr "未选择播放列表"
+
+#: src/routes/playlists.tsx:170
+msgid "New Playlist"
+msgstr "新播放列表"
+
+#: src/routes/settings.about.tsx:32
+msgid "About Museeks"
+msgstr "关于 Museeks"
+
+#: src/routes/settings.about.tsx:44
+msgid "release notes"
+msgstr "发布说明"
+
+#: src/routes/settings.about.tsx:47
+msgid "Automatically check for updates"
+msgstr "自动检查更新"
+
+#: src/routes/settings.about.tsx:57
+msgid "Check for update"
+msgstr "检查更新"
+
+#: src/routes/settings.about.tsx:63
+msgid "Contributors"
+msgstr "贡献者"
+
+#: src/routes/settings.about.tsx:66
+msgid "Made with <0/> by Pierre de la Martinière (<1>martpie.io</1>) and a bunch of <2>great people</2>"
+msgstr "由 Pierre de la Martinière (<1>martpie.io</1>) 和一群<2>优秀的人</2>使用 <0/> 制作"
+
+#: src/routes/settings.about.tsx:82
+msgid "Translations:"
+msgstr "翻译："
+
+#: src/routes/settings.about.tsx:96
+msgid "Report issue / Ask for a feature"
+msgstr "报告问题 / 请求功能"
+
+#: src/routes/settings.about.tsx:99
+msgid "Bugs happen. Please, do not hesitate to report them or to ask for features you would like to see, using the <0>issue tracker</0>."
+msgstr "错误时有发生。请不要犹豫使用<0>问题跟踪器</0>报告它们或请求您希望看到的功能。"
+
+#: src/routes/settings.about.tsx:114
+msgid "Internals"
+msgstr "内部信息"
+
+#: src/routes/settings.about.tsx:119
+msgid "Open storage directory"
+msgstr "打开存储目录"
+
+#: src/routes/settings.audio.tsx:25
+msgid "Playback rate"
+msgstr "播放速率"
+
+#: src/routes/settings.audio.tsx:26
+msgid "Increase the playback rate: a value of 2 will play your music at a 2x speed"
+msgstr "增加播放速率：值为 2 将以 2 倍速播放您的音乐"
+
+#: src/routes/settings.audio.tsx:41
+msgid "Follow playing track"
+msgstr "跟随播放音轨"
+
+#: src/routes/settings.audio.tsx:42
+msgid "Automatically follow the currently playing track (only when the app is not focused)"
+msgstr "自动跟随当前播放的音轨（仅在应用未聚焦时）"
+
+#: src/routes/settings.library.tsx:45
+msgid "Files"
+msgstr "文件"
+
+#: src/routes/settings.library.tsx:49
+msgid "There are no folders in your library."
+msgstr "您的音乐库中没有文件夹。"
+
+#: src/routes/settings.library.tsx:81
+msgid "Add folder"
+msgstr "添加文件夹"
+
+#: src/routes/settings.library.tsx:88
+msgid "Scan"
+msgstr "扫描"
+
+#: src/routes/settings.library.tsx:94
+msgid "All track data will be updated from the base files, but your original files won't be modified. Any Museeks-specific edits you may have done will be reset."
+msgstr "所有音轨数据将从基础文件更新，但您的原始文件不会被修改。您可能做过的任何 Museeks 特定编辑将被重置。"
+
+#: src/routes/settings.library.tsx:96
+msgid "Refresh all tracks?"
+msgstr "刷新所有音轨？"
+
+#: src/routes/settings.library.tsx:99
+#: src/routes/settings.library.tsx:109
+msgid "Refresh"
+msgstr "刷新"
+
+#: src/routes/settings.library.tsx:107
+msgid "Force the refresh of all tracks tags"
+msgstr "强制刷新所有音轨标签"
+
+#: src/routes/settings.library.tsx:113
+msgid "<0>.m3u</0> files will also be imported as playlists."
+msgstr "<0>.m3u</0> 文件也将作为播放列表导入。"
+
+#: src/routes/settings.library.tsx:120
+msgid "Automatically refresh library on startup"
+msgstr "启动时自动刷新音乐库"
+
+#: src/routes/settings.library.tsx:127
+msgid "Danger zone"
+msgstr "危险区域"
+
+#: src/routes/settings.library.tsx:130
+msgid "Delete all tracks and playlists from Museeks."
+msgstr "从 Museeks 中删除所有音轨和播放列表。"
+
+#: src/routes/settings.library.tsx:135
+msgid "Fully reset the library"
+msgstr "完全重置音乐库"
+
+#: src/routes/settings.library.tsx:139
+msgid "All your tracks and playlists will be deleted from Museeks."
+msgstr "您的所有音轨和播放列表将从 Museeks 中删除。"
+
+#: src/routes/settings.library.tsx:141
+msgid "Reset library?"
+msgstr "重置音乐库？"
+
+#: src/routes/settings.library.tsx:144
+#: src/routes/settings.ui.tsx:67
+msgid "Reset"
+msgstr "重置"
+
+#: src/routes/settings.library.tsx:153
+msgid "Reset library"
+msgstr "重置音乐库"
+
+#: src/routes/settings.tsx:45
+msgid "Audio"
+msgstr "音频"
+
+#: src/routes/settings.tsx:48
+msgid "Interface"
+msgstr "界面"
+
+#: src/routes/settings.tsx:51
+msgid "About"
+msgstr "关于"
+
+#: src/routes/settings.ui.tsx:38
+msgid "Theme"
+msgstr "主题"
+
+#: src/routes/settings.ui.tsx:39
+msgid "Change the appearance of the interface"
+msgstr "更改界面的外观"
+
+#: src/routes/settings.ui.tsx:45
+msgid "System (default)"
+msgstr "系统（默认）"
+
+#: src/routes/settings.ui.tsx:57
+msgid "Accent color"
+msgstr "强调色"
+
+#: src/routes/settings.ui.tsx:78
+msgid "Language"
+msgstr "语言"
+
+#: src/routes/settings.ui.tsx:97
+msgid "Tracks density"
+msgstr "音轨密度"
+
+#: src/routes/settings.ui.tsx:98
+msgid "Change the tracks spacing"
+msgstr "更改音轨间距"
+
+#: src/routes/settings.ui.tsx:107
+msgid "Normal (default)"
+msgstr "正常（默认）"
+
+#: src/routes/settings.ui.tsx:110
+msgid "Compact"
+msgstr "紧凑"
+
+#: src/routes/settings.ui.tsx:116
+msgid "Default view"
+msgstr "默认视图"
+
+#: src/routes/settings.ui.tsx:118
+msgid "Change the default view when starting the application"
+msgstr "更改启动应用程序时的默认视图"
+
+#: src/routes/settings.ui.tsx:126
+msgid "Library (default)"
+msgstr "音乐库（默认）"
+
+#: src/routes/settings.ui.tsx:135
+msgid "Display Notifications"
+msgstr "显示通知"
+
+#: src/routes/settings.ui.tsx:136
+msgid "Send notifications when the playing track changes"
+msgstr "播放音轨更改时发送通知"
+
+#: src/routes/settings.ui.tsx:145
+msgid "Sleep mode blocker"
+msgstr "睡眠模式阻止器"
+
+#: src/routes/settings.ui.tsx:146
+msgid "Prevent the computer from going into sleep mode when playing"
+msgstr "播放时防止计算机进入睡眠模式"
+
+#: src/routes/settings.ui.tsx:154
+msgid "[Beta] Wayland compatibility enhancements"
+msgstr "[测试版] Wayland 兼容性增强"
+
+#: src/routes/settings.ui.tsx:155
+msgid "If you face issues using Wayland, try out this option"
+msgstr "如果您在使用 Wayland 时遇到问题，请尝试此选项"
+
+#: src/routes/settings.ui.tsx:178
+msgid "Light"
+msgstr "浅色"
+
+#: src/routes/settings.ui.tsx:180
+msgid "Dark"
+msgstr "深色"
+
+#. placeholder {0}: track.title
+#: src/routes/tracks.$trackID.tsx:83
+msgid "Edit \"{0}\""
+msgstr "编辑 \"{0}\""
+
+#: src/routes/tracks.$trackID.tsx:109
+msgid "Album Artist"
+msgstr "专辑艺术家"
+
+#: src/routes/tracks.$trackID.tsx:123
+msgid "Track Artists"
+msgstr "音轨艺术家"
+
+#: src/routes/tracks.$trackID.tsx:124
+msgid "You can add multiple artists with commas"
+msgstr "您可以用逗号添加多个艺术家"
+
+#: src/routes/tracks.$trackID.tsx:139
+msgid "You can add multiple genres with commas"
+msgstr "您可以用逗号添加多个流派"
+
+#: src/routes/tracks.$trackID.tsx:153
+msgid "Year"
+msgstr "年份"
+
+#: src/routes/tracks.$trackID.tsx:167
+msgid "Track Nº"
+msgstr "音轨编号"
+
+#: src/routes/tracks.$trackID.tsx:181
+#: src/routes/tracks.$trackID.tsx:213
+msgid "Of"
+msgstr "共"
+
+#: src/routes/tracks.$trackID.tsx:199
+msgid "Disk Nº"
+msgstr "磁盘编号"
+
+#: src/routes/tracks.$trackID.tsx:238
+msgid "Path"
+msgstr "路径"
+
+#: src/routes/tracks.$trackID.tsx:249
+msgid "Save"
+msgstr "保存"
+
+#: src/routes/tracks.$trackID.tsx:254
+msgid "Clicking \"save\" will only update the library data, but will not save it to the original file."
+msgstr "点击\"保存\"只会更新音乐库数据，但不会保存到原始文件。"
+
+#: src/stores/PlaylistsAPI.ts:38
+msgid "The playlist \"{name}\" was created"
+msgstr "播放列表 \"{name}\" 已创建"
+
+#. placeholder {0}: newRelease.tag_name
+#: src/stores/SettingsAPI.ts:168
+msgid "Museeks {0} is available, check https://museeks.io!"
+msgstr "Museeks {0} 可用，请查看 https://museeks.io！"
+
+#: src/stores/SettingsAPI.ts:170
+msgid "Museeks {currentVersion} is the latest version available."
+msgstr "Museeks {currentVersion} 是可用的最新版本。"
+
+#. placeholder {0}: scanResult.track_count
+#: src/stores/useLibraryStore.ts:101
+msgid "{0} track(s) were refreshed."
+msgstr "{0} 首音轨已刷新。"
+
+#. placeholder {0}: scanResult.track_count
+#: src/stores/useLibraryStore.ts:102
+msgid "{0} track(s) were added to the library."
+msgstr "{0} 首音轨已添加到音乐库。"
+
+#. placeholder {0}: scanResult.playlist_count
+#: src/stores/useLibraryStore.ts:112
+msgid "{0} playlist(s) were added to the library."
+msgstr "{0} 个播放列表已添加到音乐库。"
+
+#: src/stores/useLibraryStore.ts:173
+msgid "Library was reset"
+msgstr "音乐库已重置"


### PR DESCRIPTION
- Add Simplified Chinese language support to languages.ts
- Create complete zh-CN.po file with 140 translated strings
- Include translations for UI elements, settings, and user messages
- Support for pluralization and placeholders
- Contributor: Tang Shijian