### PR TITLE
Add native MPRIS support on Linux

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -147,6 +147,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-fs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
 name = "async-io"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2746,6 +2757,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "mpris-server"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "058bc2227727af394f34aa51da3e36aeecf2c808f39315d35f754872660750ae"
+dependencies = [
+ "async-channel",
+ "futures-channel",
+ "serde",
+ "trait-variant",
+ "zbus 4.4.0",
+]
+
+[[package]]
 name = "muda"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2782,6 +2806,7 @@ dependencies = [
  "log",
  "m3u",
  "memoize",
+ "mpris-server",
  "nosleep",
  "pathdiff",
  "rayon",
@@ -2846,6 +2871,19 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
 
 [[package]]
 name = "nix"
@@ -2941,7 +2979,7 @@ dependencies = [
  "mac-notification-sys",
  "serde",
  "tauri-winrt-notification",
- "zbus",
+ "zbus 5.14.0",
 ]
 
 [[package]]
@@ -3304,7 +3342,7 @@ checksum = "e4022a17595a00d6a369236fdae483f0de7f0a339960a53118b818238e132224"
 dependencies = [
  "android_system_properties",
  "log",
- "nix",
+ "nix 0.30.1",
  "objc2",
  "objc2-foundation",
  "objc2-ui-kit",
@@ -4933,6 +4971,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "string_cache"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5410,7 +5454,7 @@ dependencies = [
  "thiserror 2.0.18",
  "url 2.5.8",
  "windows 0.61.3",
- "zbus",
+ "zbus 5.14.0",
 ]
 
 [[package]]
@@ -5488,7 +5532,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "windows-sys 0.60.2",
- "zbus",
+ "zbus 5.14.0",
 ]
 
 [[package]]
@@ -5987,6 +6031,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "trait-variant"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70977707304198400eb4835a78f6a9f928bf41bba420deb8fdb175cd965d77a7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6820,6 +6875,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
@@ -7369,6 +7433,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
+name = "xdg-home"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7389,6 +7463,44 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "zbus"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-fs",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix 0.29.0",
+ "ordered-stream",
+ "rand 0.8.5",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.52.0",
+ "xdg-home",
+ "zbus_macros 4.4.0",
+ "zbus_names 3.0.0",
+ "zvariant 4.2.0",
 ]
 
 [[package]]
@@ -7421,9 +7533,22 @@ dependencies = [
  "uuid",
  "windows-sys 0.61.2",
  "winnow 0.7.14",
- "zbus_macros",
- "zbus_names",
- "zvariant",
+ "zbus_macros 5.14.0",
+ "zbus_names 4.3.1",
+ "zvariant 5.10.0",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+dependencies = [
+ "proc-macro-crate 3.4.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils 2.1.0",
 ]
 
 [[package]]
@@ -7436,9 +7561,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "zbus_names",
- "zvariant",
- "zvariant_utils",
+ "zbus_names 4.3.1",
+ "zvariant 5.10.0",
+ "zvariant_utils 3.3.0",
+]
+
+[[package]]
+name = "zbus_names"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant 4.2.0",
 ]
 
 [[package]]
@@ -7449,7 +7585,7 @@ checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
 dependencies = [
  "serde",
  "winnow 0.7.14",
- "zvariant",
+ "zvariant 5.10.0",
 ]
 
 [[package]]
@@ -7555,6 +7691,19 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zvariant_derive 4.2.0",
+]
+
+[[package]]
+name = "zvariant"
 version = "5.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5708299b21903bbe348e94729f22c49c55d04720a004aa350f1f9c122fd2540b"
@@ -7563,8 +7712,21 @@ dependencies = [
  "enumflags2",
  "serde",
  "winnow 0.7.14",
- "zvariant_derive",
- "zvariant_utils",
+ "zvariant_derive 5.10.0",
+ "zvariant_utils 3.3.0",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
+dependencies = [
+ "proc-macro-crate 3.4.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils 2.1.0",
 ]
 
 [[package]]
@@ -7577,7 +7739,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "zvariant_utils",
+ "zvariant_utils 3.3.0",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -58,6 +58,9 @@ ts-rs = "12.0.1"
 uuid = { version = "1.22.0", features = ["v3", "v4", "fast-rng"] }
 walkdir = "2.5.0"
 
+[target.'cfg(target_os = "linux")'.dependencies]
+mpris-server = "0.8"
+
 [profile.dev]
 incremental = true # Compile your binary in smaller steps.
 

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -49,6 +49,18 @@ fn main() {
             .plugin(
                 "sleepblocker",
                 tauri_build::InlinedPlugin::new().commands(&["enable", "disable"]),
+            )
+            .plugin(
+                "mpris",
+                tauri_build::InlinedPlugin::new().commands(&[
+                    "update_playback_status",
+                    "update_track_metadata",
+                    "update_volume",
+                    "update_shuffle",
+                    "update_repeat",
+                    "update_position",
+                    "clear_metadata",
+                ]),
             ),
     )
     .expect("Failed to run tauri-build");

--- a/src-tauri/capabilities/main.json
+++ b/src-tauri/capabilities/main.json
@@ -51,7 +51,14 @@
     "database:allow-reset",
     "default-view:allow-set",
     "sleepblocker:allow-enable",
-    "sleepblocker:allow-disable"
+    "sleepblocker:allow-disable",
+    "mpris:allow-update-playback-status",
+    "mpris:allow-update-track-metadata",
+    "mpris:allow-update-volume",
+    "mpris:allow-update-shuffle",
+    "mpris:allow-update-repeat",
+    "mpris:allow-update-position",
+    "mpris:allow-clear-metadata"
   ],
   "platforms": ["linux", "macOS", "windows"]
 }

--- a/src-tauri/src/libs/events.rs
+++ b/src-tauri/src/libs/events.rs
@@ -13,6 +13,12 @@ pub enum IPCEvent<'a> {
     PlaybackPrevious,
     PlaybackNext,
     PlaybackStart,
+    // MPRIS-related playback events
+    PlaybackSeekTo,
+    PlaybackSeekBy,
+    PlaybackSetVolume,
+    PlaybackSetShuffle,
+    PlaybackSetRepeat,
     // Scan-related events
     LibraryScanProgress,
     // Menu-related events

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -98,6 +98,10 @@ fn main() {
                 .build(),
         );
 
+    // Native MPRIS integration for Linux
+    #[cfg(target_os = "linux")]
+    let builder = builder.plugin(plugins::mpris::init());
+
     // Experimental: local HTTP server for audio streaming
     // (WebKitGTK's asset protocol doesn't support media streaming)
     let builder = if enable_stream_server {

--- a/src-tauri/src/plugins/mod.rs
+++ b/src-tauri/src/plugins/mod.rs
@@ -24,5 +24,7 @@ pub mod db;
  * Settings-related plugins
  */
 pub mod default_view;
+#[cfg(target_os = "linux")]
+pub mod mpris;
 pub mod sleepblocker;
 pub mod stream_server;

--- a/src-tauri/src/plugins/mpris.rs
+++ b/src-tauri/src/plugins/mpris.rs
@@ -1,0 +1,554 @@
+use std::sync::{Arc, Mutex};
+
+use log::{error, info};
+use mpris_server::{
+    zbus::{self, fdo},
+    LoopStatus, Metadata, PlaybackStatus, PlayerInterface, Property, RootInterface, Server, Signal,
+    Time, TrackId,
+};
+use tauri::plugin::{Builder, TauriPlugin};
+use tauri::{Emitter, Manager, Runtime, State};
+
+use crate::libs::error::AnyResult;
+use crate::libs::events::IPCEvent;
+
+/// Internal state shared between the MPRIS server and Tauri commands.
+struct MprisInner {
+    playback_status: Mutex<PlaybackStatus>,
+    metadata: Mutex<Metadata>,
+    volume: Mutex<f64>,
+    shuffle: Mutex<bool>,
+    loop_status: Mutex<LoopStatus>,
+    position: Mutex<Time>,
+}
+
+/// The MPRIS implementation that handles D-Bus interface methods.
+/// Methods like play/pause/next are forwarded to the frontend via Tauri events.
+struct MprisImpl {
+    inner: Arc<MprisInner>,
+    app_handle: Mutex<Option<Box<dyn EmitAll>>>,
+}
+
+/// Trait object wrapper for AppHandle emission (needed because AppHandle is generic over Runtime).
+trait EmitAll: Send + Sync {
+    fn emit_event(&self, event: &str, payload: ());
+    fn emit_f64(&self, event: &str, payload: f64);
+    fn emit_bool(&self, event: &str, payload: bool);
+    fn emit_string(&self, event: &str, payload: String);
+}
+
+struct TauriEmitter<R: Runtime> {
+    handle: tauri::AppHandle<R>,
+}
+
+impl<R: Runtime> EmitAll for TauriEmitter<R> {
+    fn emit_event(&self, event: &str, payload: ()) {
+        let _ = self.handle.emit(event, payload);
+    }
+    fn emit_f64(&self, event: &str, payload: f64) {
+        let _ = self.handle.emit(event, payload);
+    }
+    fn emit_bool(&self, event: &str, payload: bool) {
+        let _ = self.handle.emit(event, payload);
+    }
+    fn emit_string(&self, event: &str, payload: String) {
+        let _ = self.handle.emit(event, payload);
+    }
+}
+
+impl RootInterface for MprisImpl {
+    async fn raise(&self) -> fdo::Result<()> {
+        Ok(())
+    }
+
+    async fn quit(&self) -> fdo::Result<()> {
+        Ok(())
+    }
+
+    async fn can_quit(&self) -> fdo::Result<bool> {
+        Ok(false)
+    }
+
+    async fn fullscreen(&self) -> fdo::Result<bool> {
+        Ok(false)
+    }
+
+    async fn set_fullscreen(&self, _fullscreen: bool) -> zbus::Result<()> {
+        Ok(())
+    }
+
+    async fn can_set_fullscreen(&self) -> fdo::Result<bool> {
+        Ok(false)
+    }
+
+    async fn can_raise(&self) -> fdo::Result<bool> {
+        Ok(false)
+    }
+
+    async fn has_track_list(&self) -> fdo::Result<bool> {
+        Ok(false)
+    }
+
+    async fn identity(&self) -> fdo::Result<String> {
+        Ok("Museeks".to_string())
+    }
+
+    async fn desktop_entry(&self) -> fdo::Result<String> {
+        Ok("museeks".to_string())
+    }
+
+    async fn supported_uri_schemes(&self) -> fdo::Result<Vec<String>> {
+        Ok(vec!["file".to_string()])
+    }
+
+    async fn supported_mime_types(&self) -> fdo::Result<Vec<String>> {
+        Ok(crate::libs::database::SUPPORTED_AUDIO_FORMATS
+            .iter()
+            .map(|(_, mime)| (*mime).to_string())
+            .collect())
+    }
+}
+
+impl PlayerInterface for MprisImpl {
+    async fn next(&self) -> fdo::Result<()> {
+        if let Some(emitter) = self.app_handle.lock().unwrap().as_ref() {
+            emitter.emit_event(IPCEvent::PlaybackNext.as_ref(), ());
+        }
+        Ok(())
+    }
+
+    async fn previous(&self) -> fdo::Result<()> {
+        if let Some(emitter) = self.app_handle.lock().unwrap().as_ref() {
+            emitter.emit_event(IPCEvent::PlaybackPrevious.as_ref(), ());
+        }
+        Ok(())
+    }
+
+    async fn pause(&self) -> fdo::Result<()> {
+        if let Some(emitter) = self.app_handle.lock().unwrap().as_ref() {
+            emitter.emit_event(IPCEvent::PlaybackPause.as_ref(), ());
+        }
+        Ok(())
+    }
+
+    async fn play_pause(&self) -> fdo::Result<()> {
+        if let Some(emitter) = self.app_handle.lock().unwrap().as_ref() {
+            emitter.emit_event(IPCEvent::PlaybackPlayPause.as_ref(), ());
+        }
+        Ok(())
+    }
+
+    async fn stop(&self) -> fdo::Result<()> {
+        if let Some(emitter) = self.app_handle.lock().unwrap().as_ref() {
+            emitter.emit_event(IPCEvent::PlaybackStop.as_ref(), ());
+        }
+        Ok(())
+    }
+
+    async fn play(&self) -> fdo::Result<()> {
+        if let Some(emitter) = self.app_handle.lock().unwrap().as_ref() {
+            emitter.emit_event(IPCEvent::PlaybackPlay.as_ref(), ());
+        }
+        Ok(())
+    }
+
+    async fn seek(&self, offset: Time) -> fdo::Result<()> {
+        if let Some(emitter) = self.app_handle.lock().unwrap().as_ref() {
+            // Relative seek: send offset in seconds, frontend applies it to its own currentTime
+            let offset_secs = offset.as_micros() as f64 / 1_000_000.0;
+            emitter.emit_f64(IPCEvent::PlaybackSeekBy.as_ref(), offset_secs);
+        }
+        Ok(())
+    }
+
+    async fn set_position(&self, _track_id: TrackId, position: Time) -> fdo::Result<()> {
+        if let Some(emitter) = self.app_handle.lock().unwrap().as_ref() {
+            // Convert position from microseconds to seconds
+            let position_secs = position.as_micros() as f64 / 1_000_000.0;
+            emitter.emit_f64(IPCEvent::PlaybackSeekTo.as_ref(), position_secs);
+        }
+        Ok(())
+    }
+
+    async fn open_uri(&self, _uri: String) -> fdo::Result<()> {
+        Ok(())
+    }
+
+    async fn playback_status(&self) -> fdo::Result<PlaybackStatus> {
+        Ok(*self.inner.playback_status.lock().unwrap())
+    }
+
+    async fn loop_status(&self) -> fdo::Result<LoopStatus> {
+        Ok(*self.inner.loop_status.lock().unwrap())
+    }
+
+    async fn set_loop_status(&self, loop_status: LoopStatus) -> zbus::Result<()> {
+        *self.inner.loop_status.lock().unwrap() = loop_status;
+        if let Some(emitter) = self.app_handle.lock().unwrap().as_ref() {
+            let repeat = match loop_status {
+                LoopStatus::None => "None",
+                LoopStatus::Track => "One",
+                LoopStatus::Playlist => "All",
+            };
+            emitter.emit_string(
+                IPCEvent::PlaybackSetRepeat.as_ref(),
+                repeat.to_string(),
+            );
+        }
+        Ok(())
+    }
+
+    async fn rate(&self) -> fdo::Result<f64> {
+        Ok(1.0)
+    }
+
+    async fn set_rate(&self, _rate: f64) -> zbus::Result<()> {
+        Ok(())
+    }
+
+    async fn shuffle(&self) -> fdo::Result<bool> {
+        Ok(*self.inner.shuffle.lock().unwrap())
+    }
+
+    async fn set_shuffle(&self, shuffle: bool) -> zbus::Result<()> {
+        *self.inner.shuffle.lock().unwrap() = shuffle;
+        if let Some(emitter) = self.app_handle.lock().unwrap().as_ref() {
+            emitter.emit_bool(IPCEvent::PlaybackSetShuffle.as_ref(), shuffle);
+        }
+        Ok(())
+    }
+
+    async fn metadata(&self) -> fdo::Result<Metadata> {
+        Ok(self.inner.metadata.lock().unwrap().clone())
+    }
+
+    async fn volume(&self) -> fdo::Result<f64> {
+        Ok(*self.inner.volume.lock().unwrap())
+    }
+
+    async fn set_volume(&self, volume: f64) -> zbus::Result<()> {
+        *self.inner.volume.lock().unwrap() = volume;
+        if let Some(emitter) = self.app_handle.lock().unwrap().as_ref() {
+            emitter.emit_f64(IPCEvent::PlaybackSetVolume.as_ref(), volume);
+        }
+        Ok(())
+    }
+
+    async fn position(&self) -> fdo::Result<Time> {
+        Ok(*self.inner.position.lock().unwrap())
+    }
+
+    async fn minimum_rate(&self) -> fdo::Result<f64> {
+        Ok(1.0)
+    }
+
+    async fn maximum_rate(&self) -> fdo::Result<f64> {
+        Ok(1.0)
+    }
+
+    async fn can_go_next(&self) -> fdo::Result<bool> {
+        Ok(true)
+    }
+
+    async fn can_go_previous(&self) -> fdo::Result<bool> {
+        Ok(true)
+    }
+
+    async fn can_play(&self) -> fdo::Result<bool> {
+        Ok(true)
+    }
+
+    async fn can_pause(&self) -> fdo::Result<bool> {
+        Ok(true)
+    }
+
+    async fn can_seek(&self) -> fdo::Result<bool> {
+        Ok(true)
+    }
+
+    async fn can_control(&self) -> fdo::Result<bool> {
+        Ok(true)
+    }
+}
+
+/// Managed state that holds the MPRIS server.
+pub struct MprisState {
+    server: Server<MprisImpl>,
+    inner: Arc<MprisInner>,
+}
+
+// --------------------------------------------------------------------------
+// Tauri commands
+// --------------------------------------------------------------------------
+
+#[tauri::command]
+pub async fn update_playback_status(
+    state: State<'_, MprisState>,
+    playing: bool,
+) -> AnyResult<()> {
+    let status = if playing {
+        PlaybackStatus::Playing
+    } else {
+        PlaybackStatus::Paused
+    };
+    *state.inner.playback_status.lock().unwrap() = status;
+    state
+        .server
+        .properties_changed([Property::PlaybackStatus(status)])
+        .await
+        .map_err(|e| anyhow::anyhow!("MPRIS error: {}", e))?;
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn update_track_metadata(
+    state: State<'_, MprisState>,
+    title: String,
+    artists: Vec<String>,
+    album: String,
+    duration_secs: u32,
+    cover_path: Option<String>,
+    track_no: Option<u32>,
+    track_id: String,
+) -> AnyResult<()> {
+    let mut metadata = Metadata::builder()
+        .title(title)
+        .artist(artists)
+        .album(album)
+        .length(Time::from_secs(duration_secs as i64));
+
+    // Set track ID as a D-Bus object path
+    let track_path = format!("/org/museeks/track/{}", track_id.replace('-', "_"));
+    if let Ok(tid) = TrackId::try_from(track_path.as_str()) {
+        metadata = metadata.trackid(tid);
+    }
+
+    if let Some(track_no) = track_no {
+        metadata = metadata.track_number(track_no as i32);
+    }
+
+    if let Some(cover) = cover_path {
+        if let Some(art_url) = resolve_cover_art(&cover) {
+            metadata = metadata.art_url(art_url);
+        }
+    }
+
+    let metadata = metadata.build();
+    *state.inner.metadata.lock().unwrap() = metadata.clone();
+    state
+        .server
+        .properties_changed([Property::Metadata(metadata)])
+        .await
+        .map_err(|e| anyhow::anyhow!("MPRIS error: {}", e))?;
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn update_volume(state: State<'_, MprisState>, volume: f64) -> AnyResult<()> {
+    *state.inner.volume.lock().unwrap() = volume;
+    state
+        .server
+        .properties_changed([Property::Volume(volume)])
+        .await
+        .map_err(|e| anyhow::anyhow!("MPRIS error: {}", e))?;
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn update_shuffle(state: State<'_, MprisState>, shuffle: bool) -> AnyResult<()> {
+    *state.inner.shuffle.lock().unwrap() = shuffle;
+    state
+        .server
+        .properties_changed([Property::Shuffle(shuffle)])
+        .await
+        .map_err(|e| anyhow::anyhow!("MPRIS error: {}", e))?;
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn update_repeat(state: State<'_, MprisState>, repeat: String) -> AnyResult<()> {
+    let loop_status = match repeat.as_str() {
+        "All" => LoopStatus::Playlist,
+        "One" => LoopStatus::Track,
+        _ => LoopStatus::None,
+    };
+    *state.inner.loop_status.lock().unwrap() = loop_status;
+    state
+        .server
+        .properties_changed([Property::LoopStatus(loop_status)])
+        .await
+        .map_err(|e| anyhow::anyhow!("MPRIS error: {}", e))?;
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn update_position(
+    state: State<'_, MprisState>,
+    position_secs: f64,
+    seeked: Option<bool>,
+) -> AnyResult<()> {
+    let position = Time::from_micros((position_secs * 1_000_000.0) as i64);
+    *state.inner.position.lock().unwrap() = position;
+    // Only emit Seeked signal on actual seeks, not periodic position syncs
+    if seeked.unwrap_or(false) {
+        state
+            .server
+            .emit(Signal::Seeked { position })
+            .await
+            .map_err(|e| anyhow::anyhow!("MPRIS error: {}", e))?;
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn clear_metadata(state: State<'_, MprisState>) -> AnyResult<()> {
+    *state.inner.playback_status.lock().unwrap() = PlaybackStatus::Stopped;
+    *state.inner.metadata.lock().unwrap() = Metadata::new();
+    *state.inner.position.lock().unwrap() = Time::ZERO;
+    state
+        .server
+        .properties_changed([
+            Property::PlaybackStatus(PlaybackStatus::Stopped),
+            Property::Metadata(Metadata::new()),
+        ])
+        .await
+        .map_err(|e| anyhow::anyhow!("MPRIS error: {}", e))?;
+    Ok(())
+}
+
+// --------------------------------------------------------------------------
+// Cover art helpers
+// --------------------------------------------------------------------------
+
+/// Simple percent-decode for URL paths.
+fn percent_decode(input: &str) -> String {
+    let mut result = Vec::with_capacity(input.len());
+    let bytes = input.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            if let Ok(byte) = u8::from_str_radix(
+                std::str::from_utf8(&bytes[i + 1..i + 3]).unwrap_or(""),
+                16,
+            ) {
+                result.push(byte);
+                i += 3;
+                continue;
+            }
+        }
+        result.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8(result).unwrap_or_else(|_| input.to_string())
+}
+
+/// Convert a cover path from the frontend to a file:// URI for MPRIS.
+fn resolve_cover_art(cover: &str) -> Option<String> {
+    if cover.starts_with("data:") {
+        // Decode base64 data URL and write to temp file
+        write_cover_from_data_url(cover)
+    } else if cover.starts_with("http://") || cover.starts_with("https://") {
+        // Asset protocol URLs — pass through
+        Some(cover.to_string())
+    } else if cover.starts_with("asset://") {
+        // Tauri asset protocol — extract the path and percent-decode it
+        let path = cover.strip_prefix("asset://localhost")?;
+        let decoded = percent_decode(path);
+        Some(format!("file://{}", decoded))
+    } else {
+        // Assume file path
+        Some(format!("file://{}", cover))
+    }
+}
+
+/// Decode a data: URL and write the image to a temp file.
+fn write_cover_from_data_url(data_url: &str) -> Option<String> {
+    use base64::Engine;
+    use std::fs;
+
+    // Parse: data:image/png;base64,<data>
+    let after_comma = data_url.find(',')? + 1;
+    let base64_data = &data_url[after_comma..];
+
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(base64_data)
+        .ok()?;
+
+    let temp_path = std::env::temp_dir().join("museeks-cover.png");
+    fs::write(&temp_path, &bytes).ok()?;
+    Some(format!("file://{}", temp_path.display()))
+}
+
+// --------------------------------------------------------------------------
+// Plugin initialization
+// --------------------------------------------------------------------------
+
+pub fn init<R: Runtime>() -> TauriPlugin<R> {
+    Builder::<R>::new("mpris")
+        .invoke_handler(tauri::generate_handler![
+            update_playback_status,
+            update_track_metadata,
+            update_volume,
+            update_shuffle,
+            update_repeat,
+            update_position,
+            clear_metadata,
+        ])
+        .setup(|app_handle, _api| {
+            let inner = Arc::new(MprisInner {
+                playback_status: Mutex::new(PlaybackStatus::Stopped),
+                metadata: Mutex::new(Metadata::new()),
+                volume: Mutex::new(1.0),
+                shuffle: Mutex::new(false),
+                loop_status: Mutex::new(LoopStatus::None),
+                position: Mutex::new(Time::ZERO),
+            });
+
+            let mpris_impl = MprisImpl {
+                inner: Arc::clone(&inner),
+                app_handle: Mutex::new(Some(Box::new(TauriEmitter {
+                    handle: app_handle.clone(),
+                }))),
+            };
+
+            // Create the MPRIS server on a background thread (zbus needs its own async runtime)
+            let (tx, rx) = std::sync::mpsc::channel();
+            let inner_clone = Arc::clone(&inner);
+
+            std::thread::spawn(move || {
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("Failed to build tokio runtime for MPRIS");
+
+                rt.block_on(async {
+                    match Server::new("museeks", mpris_impl).await {
+                        Ok(server) => {
+                            info!("MPRIS server started as org.mpris.MediaPlayer2.museeks");
+                            let state = MprisState {
+                                server,
+                                inner: inner_clone,
+                            };
+                            tx.send(Ok(state)).unwrap();
+                            // Keep the runtime alive so the D-Bus connection stays open
+                            std::future::pending::<()>().await;
+                        }
+                        Err(e) => {
+                            error!("Failed to start MPRIS server: {}", e);
+                            tx.send(Err(anyhow::anyhow!("Failed to start MPRIS server: {}", e)))
+                                .unwrap();
+                        }
+                    }
+                });
+            });
+
+            let state = rx
+                .recv()
+                .map_err(|e| anyhow::anyhow!("MPRIS channel error: {}", e))??;
+
+            app_handle.manage(state);
+            info!("MPRIS plugin initialized");
+            Ok(())
+        })
+        .build()
+}

--- a/src-tauri/src/plugins/stream_server.rs
+++ b/src-tauri/src/plugins/stream_server.rs
@@ -75,6 +75,7 @@ fn build_response(
         content_length.to_string().parse().unwrap(),
     );
     headers.insert(header::ACCEPT_RANGES, "bytes".parse().unwrap());
+    headers.insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, "*".parse().unwrap());
 
     if let Some((start, end)) = range {
         headers.insert(

--- a/src/components/IPCPlayerEvents.tsx
+++ b/src/components/IPCPlayerEvents.tsx
@@ -1,8 +1,9 @@
 import { listen } from '@tauri-apps/api/event';
 import { useEffect } from 'react';
 
-import type { IPCEvent, Track } from '../generated/typings';
+import type { IPCEvent, Repeat, Track } from '../generated/typings';
 import player from '../lib/player';
+import { smoothifyVolume } from '../lib/utils-player';
 
 /**
  * Handle back-end events attempting to control the player
@@ -22,6 +23,37 @@ function IPCPlayerEvents() {
           if (payload.length > 0) {
             await player.start(payload, payload[0].id, { type: 'library' });
           }
+        },
+      ),
+      listen(
+        'PlaybackSeekTo' satisfies IPCEvent,
+        ({ payload }: { payload: number }) => {
+          player.setCurrentTime(payload);
+        },
+      ),
+      listen(
+        'PlaybackSeekBy' satisfies IPCEvent,
+        ({ payload }: { payload: number }) => {
+          player.setCurrentTime(player.getCurrentTime() + payload);
+        },
+      ),
+      listen(
+        'PlaybackSetVolume' satisfies IPCEvent,
+        ({ payload }: { payload: number }) => {
+          // Convert from perceptual MPRIS volume to audio gain (smoothed)
+          player.setVolume(smoothifyVolume(payload));
+        },
+      ),
+      listen(
+        'PlaybackSetShuffle' satisfies IPCEvent,
+        ({ payload }: { payload: boolean }) => {
+          void player.setShuffle(payload);
+        },
+      ),
+      listen(
+        'PlaybackSetRepeat' satisfies IPCEvent,
+        ({ payload }: { payload: Repeat }) => {
+          void player.setRepeat(payload);
         },
       ),
     ];

--- a/src/components/VolumeControl.tsx
+++ b/src/components/VolumeControl.tsx
@@ -8,14 +8,8 @@ import ButtonIcon from '../elements/ButtonIcon';
 import { usePlayerState } from '../hooks/usePlayer';
 import player from '../lib/player';
 import { stopPropagation } from '../lib/utils-events';
+import { smoothifyVolume, unsmoothifyVolume } from '../lib/utils-player';
 import type { IconName } from './Icon';
-
-// Volume easing - http://www.dr-lex.be/info-stuff/volumecontrols.html#about
-const SMOOTHING_FACTOR = 2.5;
-
-const smoothifyVolume = (value: number): number => value ** SMOOTHING_FACTOR;
-const unsmoothifyVolume = (value: number): number =>
-  value ** (1.0 / SMOOTHING_FACTOR);
 
 const getVolumeIcon = (volume: number, muted: boolean): IconName => {
   if (muted) return 'volumeMute';

--- a/src/generated/typings.ts
+++ b/src/generated/typings.ts
@@ -4,7 +4,7 @@ export type Config = { language: string, theme: string, ui_accent_color: string 
 
 export type DefaultView = "Library" | "Artists" | "Playlists";
 
-export type IPCEvent = { "Unknown": string } | "PlaybackPlay" | "PlaybackPause" | "PlaybackStop" | "PlaybackPlayPause" | "PlaybackPrevious" | "PlaybackNext" | "PlaybackStart" | "LibraryScanProgress" | "GoToLibrary" | "GoToPlaylists" | "GoToSettings" | "JumpToPlayingTrack";
+export type IPCEvent = { "Unknown": string } | "PlaybackPlay" | "PlaybackPause" | "PlaybackStop" | "PlaybackPlayPause" | "PlaybackPrevious" | "PlaybackNext" | "PlaybackStart" | "PlaybackSeekTo" | "PlaybackSeekBy" | "PlaybackSetVolume" | "PlaybackSetShuffle" | "PlaybackSetRepeat" | "LibraryScanProgress" | "GoToLibrary" | "GoToPlaylists" | "GoToSettings" | "JumpToPlayingTrack";
 
 /** ----------------------------------------------------------------------------
  * Playlist

--- a/src/lib/bridge-mpris.ts
+++ b/src/lib/bridge-mpris.ts
@@ -1,0 +1,56 @@
+import { invoke } from '@tauri-apps/api/core';
+import { type as osType } from '@tauri-apps/plugin-os';
+
+import { unsmoothifyVolume } from './utils-player';
+
+const isLinux = osType() === 'linux';
+
+const MprisBridge = {
+  async updatePlaybackStatus(playing: boolean): Promise<void> {
+    if (!isLinux) return;
+    await invoke('plugin:mpris|update_playback_status', { playing });
+  },
+
+  async updateTrackMetadata(metadata: {
+    title: string;
+    artists: string[];
+    album: string;
+    durationSecs: number;
+    coverPath: string | null;
+    trackNo: number | null;
+    trackId: string;
+  }): Promise<void> {
+    if (!isLinux) return;
+    await invoke('plugin:mpris|update_track_metadata', metadata);
+  },
+
+  async updateVolume(volume: number): Promise<void> {
+    if (!isLinux) return;
+    // Convert from audio gain (smoothed) to perceptual 0-1 for MPRIS
+    await invoke('plugin:mpris|update_volume', {
+      volume: unsmoothifyVolume(volume),
+    });
+  },
+
+  async updateShuffle(shuffle: boolean): Promise<void> {
+    if (!isLinux) return;
+    await invoke('plugin:mpris|update_shuffle', { shuffle });
+  },
+
+  async updateRepeat(repeat: string): Promise<void> {
+    if (!isLinux) return;
+    await invoke('plugin:mpris|update_repeat', { repeat });
+  },
+
+  async updatePosition(positionSecs: number, seeked = false): Promise<void> {
+    if (!isLinux) return;
+    await invoke('plugin:mpris|update_position', { positionSecs, seeked });
+  },
+
+  async clearMetadata(): Promise<void> {
+    if (!isLinux) return;
+    await invoke('plugin:mpris|clear_metadata');
+  },
+};
+
+export default MprisBridge;

--- a/src/lib/player.ts
+++ b/src/lib/player.ts
@@ -1,13 +1,19 @@
 import { convertFileSrc } from '@tauri-apps/api/core';
+import { type as osType } from '@tauri-apps/plugin-os';
 import EventEmitter from 'eventemitter3';
 import debounce from 'lodash-es/debounce';
+import throttle from 'lodash-es/throttle';
 
 import type { Repeat, Track } from '../generated/typings';
 import type { QueueOrigin } from '../types/museeks';
 import ConfigBridge from './bridge-config';
+import MprisBridge from './bridge-mpris';
 import { getCover } from './cover';
 import { logAndNotifyError } from './utils';
 import { shuffleTracks } from './utils-player';
+import { WebAudioElement } from './web-audio-element';
+
+const isLinux = osType() === 'linux';
 
 interface PlayerOptions {
   playbackRate?: number;
@@ -56,7 +62,7 @@ export interface PlayerEvents {
  * Extends EventEmitter to notify React components of state changes.
  */
 class Player extends EventEmitter<PlayerEvents> {
-  private readonly audio: HTMLAudioElement;
+  private readonly audio: HTMLAudioElement | WebAudioElement;
 
   // Queue state
   private queue: Track[];
@@ -83,7 +89,8 @@ class Player extends EventEmitter<PlayerEvents> {
       ...options,
     };
 
-    this.audio = new Audio();
+    // On Linux, use Web Audio API so WebKitGTK's MPRIS entry stays inactive (Stopped)
+    this.audio = isLinux ? new WebAudioElement() : new Audio();
     this.queue = [];
     this.oldQueue = [];
     this.queueCursor = null;
@@ -115,6 +122,8 @@ class Player extends EventEmitter<PlayerEvents> {
     this.setQueue = this.setQueue.bind(this);
     this.toggleShuffle = this.toggleShuffle.bind(this);
     this.toggleRepeat = this.toggleRepeat.bind(this);
+    this.setShuffle = this.setShuffle.bind(this);
+    this.setRepeat = this.setRepeat.bind(this);
     this.setTrack = this.setTrack.bind(this);
     this.setCurrentTime = this.setCurrentTime.bind(this);
     this.setVolume = this.setVolume.bind(this);
@@ -130,11 +139,13 @@ class Player extends EventEmitter<PlayerEvents> {
     this.audio.addEventListener('play', () => {
       this.emit('play');
       this.emitStateChange();
+      MprisBridge.updatePlaybackStatus(true).catch(logAndNotifyError);
     });
 
     this.audio.addEventListener('pause', () => {
       this.emit('pause');
       this.emitStateChange();
+      MprisBridge.updatePlaybackStatus(false).catch(logAndNotifyError);
     });
 
     this.audio.addEventListener('ended', async () => {
@@ -151,6 +162,7 @@ class Player extends EventEmitter<PlayerEvents> {
 
     this.audio.addEventListener('timeupdate', () => {
       this.emit('timeupdate', this.audio.currentTime);
+      this.syncMprisPositionThrottled(this.audio.currentTime);
     });
 
     this.audio.addEventListener('loadstart', () => {
@@ -164,10 +176,11 @@ class Player extends EventEmitter<PlayerEvents> {
   }
 
   /**
-   * Setup MediaSession integration (for OS media controls, MPRIS, etc.)
+   * Setup MediaSession integration (for OS media controls on macOS/Windows).
+   * On Linux, native MPRIS is used instead.
    */
   private setupMediaSession() {
-    if (!('mediaSession' in navigator)) {
+    if (isLinux || !('mediaSession' in navigator)) {
       return;
     }
 
@@ -202,7 +215,7 @@ class Player extends EventEmitter<PlayerEvents> {
   }
 
   /**
-   * Sync current track metadata with MediaSession API
+   * Sync current track metadata with MediaSession API (macOS/Windows only)
    */
   private async syncMediaSession() {
     if (!('mediaSession' in navigator) || !('MediaMetadata' in globalThis)) {
@@ -282,6 +295,7 @@ class Player extends EventEmitter<PlayerEvents> {
     this.queueOrigin = null;
     this.emit('stop');
     this.emitStateChange();
+    MprisBridge.clearMetadata().catch(logAndNotifyError);
   }
 
   async playPause() {
@@ -532,6 +546,15 @@ class Player extends EventEmitter<PlayerEvents> {
     this.shuffle = nextShuffleState;
     this.emitStateChange();
     await ConfigBridge.set('audio_shuffle', nextShuffleState);
+    MprisBridge.updateShuffle(nextShuffleState).catch(logAndNotifyError);
+  }
+
+  /**
+   * Set shuffle to a specific value (used by MPRIS)
+   */
+  async setShuffle(value: boolean) {
+    if (this.shuffle === value) return;
+    await this.toggleShuffle();
   }
 
   /**
@@ -556,6 +579,18 @@ class Player extends EventEmitter<PlayerEvents> {
     this.repeat = nextRepeatState;
     this.emitStateChange();
     await ConfigBridge.set('audio_repeat', nextRepeatState);
+    MprisBridge.updateRepeat(nextRepeatState).catch(logAndNotifyError);
+  }
+
+  /**
+   * Set repeat to a specific value (used by MPRIS)
+   */
+  async setRepeat(value: Repeat) {
+    if (this.repeat === value) return;
+    this.repeat = value;
+    this.emitStateChange();
+    await ConfigBridge.set('audio_repeat', value);
+    MprisBridge.updateRepeat(value).catch(logAndNotifyError);
   }
 
   /**
@@ -588,6 +623,24 @@ class Player extends EventEmitter<PlayerEvents> {
 
     this.emit('trackChange', track);
     this.emitStateChange();
+    this.syncMprisMetadata(track).catch(logAndNotifyError);
+  }
+
+  /**
+   * Sync track metadata to native MPRIS (Linux only)
+   */
+  private async syncMprisMetadata(track: Track) {
+    const cover = await getCover(track.path);
+
+    await MprisBridge.updateTrackMetadata({
+      title: track.title,
+      artists: track.artists,
+      album: track.album,
+      durationSecs: track.duration,
+      coverPath: cover,
+      trackNo: track.track_no,
+      trackId: track.id,
+    });
   }
 
   /**
@@ -606,6 +659,7 @@ class Player extends EventEmitter<PlayerEvents> {
 
   setCurrentTime(time: number) {
     this.audio.currentTime = time;
+    MprisBridge.updatePosition(time, true).catch(logAndNotifyError);
   }
 
   getCurrentTime(): number {
@@ -616,6 +670,7 @@ class Player extends EventEmitter<PlayerEvents> {
     this.audio.volume = volume;
     this.emitStateChange();
     this.saveVolumeDebounced(volume);
+    MprisBridge.updateVolume(volume).catch(logAndNotifyError);
   }
 
   /**
@@ -624,6 +679,17 @@ class Player extends EventEmitter<PlayerEvents> {
   private readonly saveVolumeDebounced = debounce((volume: number) => {
     void ConfigBridge.set('audio_volume', volume);
   }, 500);
+
+  /**
+   * Throttled MPRIS position sync to keep the Position property accurate
+   * without excessive IPC calls
+   */
+  private readonly syncMprisPositionThrottled = throttle(
+    (positionSecs: number) => {
+      void MprisBridge.updatePosition(positionSecs);
+    },
+    1000,
+  );
 
   getVolume(): number {
     return this.audio.volume;

--- a/src/lib/utils-player.ts
+++ b/src/lib/utils-player.ts
@@ -1,5 +1,16 @@
 import type { Track } from '../generated/typings';
 
+// Volume easing - http://www.dr-lex.be/info-stuff/volumecontrols.html#about
+const SMOOTHING_FACTOR = 2.5;
+
+/** Convert perceptual (linear slider) volume to audio gain. */
+export const smoothifyVolume = (value: number): number =>
+  value ** SMOOTHING_FACTOR;
+
+/** Convert audio gain to perceptual (linear slider) volume. */
+export const unsmoothifyVolume = (value: number): number =>
+  value ** (1.0 / SMOOTHING_FACTOR);
+
 /**
  * Shuffle an array with a Player behavior in mind:
  * the currently-playing track should remain the same,

--- a/src/lib/web-audio-element.ts
+++ b/src/lib/web-audio-element.ts
@@ -1,0 +1,267 @@
+/**
+ * A drop-in replacement for HTMLAudioElement that uses the Web Audio API.
+ *
+ * On Linux/WebKitGTK, using a native <audio> element causes WebKitGTK to
+ * register its own MPRIS entry with active playback status alongside our
+ * native one. This class plays audio through AudioContext instead, so
+ * WebKitGTK's MPRIS entry stays inactive (Stopped).
+ */
+
+type EventHandler = (...args: unknown[]) => void;
+
+export class WebAudioElement {
+  private ctx: AudioContext;
+  private gainNode: GainNode;
+  private buffer: AudioBuffer | null = null;
+  private sourceNode: AudioBufferSourceNode | null = null;
+  private _src = '';
+  private _volume = 1;
+  private _muted = false;
+  private _playbackRate = 1;
+  private _defaultPlaybackRate = 1;
+  private _paused = true;
+  private _currentTime = 0;
+  private _startedAt = 0; // AudioContext.currentTime when playback started
+  private _offsetTime = 0; // Offset into the buffer in seconds
+  private timeupdateInterval: ReturnType<typeof setInterval> | null = null;
+  private listeners: Map<string, Set<EventHandler>> = new Map();
+  private abortController: AbortController | null = null;
+  private loadPromise: Promise<void> | null = null;
+
+  constructor() {
+    this.ctx = new AudioContext();
+    this.gainNode = this.ctx.createGain();
+    this.gainNode.connect(this.ctx.destination);
+  }
+
+  get src(): string {
+    return this._src;
+  }
+
+  set src(url: string) {
+    this._src = url;
+    this.stop();
+
+    if (!url) return;
+
+    this.loadPromise = this.loadAudio(url);
+  }
+
+  get paused(): boolean {
+    return this._paused;
+  }
+
+  get currentTime(): number {
+    if (!this._paused && this.sourceNode) {
+      return (
+        this._offsetTime +
+        (this.ctx.currentTime - this._startedAt) * this._playbackRate
+      );
+    }
+    return this._currentTime;
+  }
+
+  set currentTime(time: number) {
+    this._currentTime = time;
+    this._offsetTime = time;
+
+    if (!this._paused && this.buffer) {
+      this.startPlayback(time);
+    }
+  }
+
+  get duration(): number {
+    return this.buffer?.duration ?? 0;
+  }
+
+  get volume(): number {
+    return this._volume;
+  }
+
+  set volume(v: number) {
+    this._volume = v;
+    this.gainNode.gain.value = this._muted ? 0 : v;
+    this.dispatch('volumechange');
+  }
+
+  get muted(): boolean {
+    return this._muted;
+  }
+
+  set muted(m: boolean) {
+    this._muted = m;
+    this.gainNode.gain.value = m ? 0 : this._volume;
+    this.dispatch('volumechange');
+  }
+
+  get playbackRate(): number {
+    return this._playbackRate;
+  }
+
+  set playbackRate(rate: number) {
+    if (this.sourceNode) {
+      // Save current position before rate change
+      this._currentTime = this.currentTime;
+      this._offsetTime = this._currentTime;
+      this._startedAt = this.ctx.currentTime;
+      this.sourceNode.playbackRate.value = rate;
+    }
+    this._playbackRate = rate;
+  }
+
+  get defaultPlaybackRate(): number {
+    return this._defaultPlaybackRate;
+  }
+
+  set defaultPlaybackRate(rate: number) {
+    this._defaultPlaybackRate = rate;
+  }
+
+  get error(): MediaError | null {
+    return null;
+  }
+
+  async play(): Promise<void> {
+    if (this.ctx.state === 'suspended') {
+      await this.ctx.resume();
+    }
+
+    // Wait for pending load to complete
+    if (this.loadPromise) {
+      await this.loadPromise;
+    }
+
+    if (!this.buffer) return;
+
+    if (this._paused) {
+      this.startPlayback(this._currentTime);
+      this._paused = false;
+      this.dispatch('play');
+      this.startTimeUpdate();
+    }
+  }
+
+  pause(): void {
+    if (!this._paused) {
+      this._currentTime = this.currentTime;
+      this._offsetTime = this._currentTime;
+      this.stopSource();
+      this._paused = true;
+      this.dispatch('pause');
+      this.stopTimeUpdate();
+    }
+  }
+
+  addEventListener(event: string, handler: EventHandler): void {
+    if (!this.listeners.has(event)) {
+      this.listeners.set(event, new Set());
+    }
+    this.listeners.get(event)!.add(handler);
+  }
+
+  removeEventListener(event: string, handler: EventHandler): void {
+    this.listeners.get(event)?.delete(handler);
+  }
+
+  private dispatch(event: string): void {
+    const handlers = this.listeners.get(event);
+    if (handlers) {
+      for (const handler of handlers) {
+        handler();
+      }
+    }
+  }
+
+  private async loadAudio(url: string): Promise<void> {
+    // Cancel any in-progress fetch
+    this.abortController?.abort();
+    this.abortController = new AbortController();
+
+    this.dispatch('loadstart');
+
+    try {
+      const response = await fetch(url, {
+        signal: this.abortController.signal,
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      const arrayBuffer = await response.arrayBuffer();
+
+      // Check if the src changed while we were fetching
+      if (this._src !== url) return;
+
+      this.buffer = await this.ctx.decodeAudioData(arrayBuffer);
+      this._currentTime = 0;
+      this._offsetTime = 0;
+    } catch (e) {
+      if (e instanceof DOMException && e.name === 'AbortError') {
+        return; // Expected when src changes
+      }
+      this.dispatch('error');
+    }
+  }
+
+  private startPlayback(fromTime: number): void {
+    this.stopSource();
+
+    if (!this.buffer) return;
+
+    const source = this.ctx.createBufferSource();
+    source.buffer = this.buffer;
+    source.playbackRate.value = this._playbackRate;
+    source.connect(this.gainNode);
+    source.onended = () => {
+      if (this.sourceNode === source && !this._paused) {
+        this._paused = true;
+        this._currentTime = this.buffer?.duration ?? 0;
+        this.stopTimeUpdate();
+        this.dispatch('ended');
+      }
+    };
+
+    const offset = Math.max(0, Math.min(fromTime, this.buffer.duration));
+    source.start(0, offset);
+    this._startedAt = this.ctx.currentTime;
+    this._offsetTime = offset;
+    this.sourceNode = source;
+  }
+
+  private stopSource(): void {
+    if (this.sourceNode) {
+      this.sourceNode.onended = null;
+      try {
+        this.sourceNode.stop();
+      } catch {
+        // ignore if already stopped
+      }
+      this.sourceNode.disconnect();
+      this.sourceNode = null;
+    }
+  }
+
+  private stop(): void {
+    this._currentTime = 0;
+    this._offsetTime = 0;
+    this._paused = true;
+    this.stopSource();
+    this.stopTimeUpdate();
+    this.buffer = null;
+  }
+
+  private startTimeUpdate(): void {
+    this.stopTimeUpdate();
+    this.timeupdateInterval = setInterval(() => {
+      if (!this._paused) {
+        this.dispatch('timeupdate');
+      }
+    }, 250);
+  }
+
+  private stopTimeUpdate(): void {
+    if (this.timeupdateInterval !== null) {
+      clearInterval(this.timeupdateInterval);
+      this.timeupdateInterval = null;
+    }
+  }
+}

--- a/src/translations/en.po
+++ b/src/translations/en.po
@@ -272,8 +272,8 @@ msgstr "you can <0>add your music here</0>"
 msgid "Your search returned no results"
 msgstr "Your search returned no results"
 
-#: src/components/VolumeControl.tsx:47
-#: src/components/VolumeControl.tsx:74
+#: src/components/VolumeControl.tsx:41
+#: src/components/VolumeControl.tsx:68
 msgid "Volume"
 msgstr "Volume"
 

--- a/src/translations/es.po
+++ b/src/translations/es.po
@@ -272,8 +272,8 @@ msgstr "puedes <0>añadir tu música aquí</0>"
 msgid "Your search returned no results"
 msgstr "Tu búsqueda no arrojó resultados"
 
-#: src/components/VolumeControl.tsx:47
-#: src/components/VolumeControl.tsx:74
+#: src/components/VolumeControl.tsx:41
+#: src/components/VolumeControl.tsx:68
 msgid "Volume"
 msgstr "Volumen"
 

--- a/src/translations/fr.po
+++ b/src/translations/fr.po
@@ -272,8 +272,8 @@ msgstr "vous pouvez <0>ajouter votre musique ici</0>"
 msgid "Your search returned no results"
 msgstr "Votre recherche n'a retourné aucun résultat"
 
-#: src/components/VolumeControl.tsx:47
-#: src/components/VolumeControl.tsx:74
+#: src/components/VolumeControl.tsx:41
+#: src/components/VolumeControl.tsx:68
 msgid "Volume"
 msgstr "Volume"
 

--- a/src/translations/ja.po
+++ b/src/translations/ja.po
@@ -272,8 +272,8 @@ msgstr "<0>ここから音楽を追加</0>できます"
 msgid "Your search returned no results"
 msgstr "検索結果が見つかりませんでした"
 
-#: src/components/VolumeControl.tsx:47
-#: src/components/VolumeControl.tsx:74
+#: src/components/VolumeControl.tsx:41
+#: src/components/VolumeControl.tsx:68
 msgid "Volume"
 msgstr "音量"
 

--- a/src/translations/ru.po
+++ b/src/translations/ru.po
@@ -272,8 +272,8 @@ msgstr "вы можете добавить <0>вашу музыку здесь</
 msgid "Your search returned no results"
 msgstr "Ваш поиск не принёс результатов"
 
-#: src/components/VolumeControl.tsx:47
-#: src/components/VolumeControl.tsx:74
+#: src/components/VolumeControl.tsx:41
+#: src/components/VolumeControl.tsx:68
 msgid "Volume"
 msgstr "Громкость"
 

--- a/src/translations/zh-CN.po
+++ b/src/translations/zh-CN.po
@@ -272,8 +272,8 @@ msgstr "您可以<0>在这里添加音乐</0>"
 msgid "Your search returned no results"
 msgstr "您的搜索没有返回结果"
 
-#: src/components/VolumeControl.tsx:47
-#: src/components/VolumeControl.tsx:74
+#: src/components/VolumeControl.tsx:41
+#: src/components/VolumeControl.tsx:68
 msgid "Volume"
 msgstr "音量"
 

--- a/src/translations/zh-TW.po
+++ b/src/translations/zh-TW.po
@@ -272,8 +272,8 @@ msgstr "您可以<0>在這裡新增音樂</0>"
 msgid "Your search returned no results"
 msgstr "您的搜尋沒有找到結果"
 
-#: src/components/VolumeControl.tsx:47
-#: src/components/VolumeControl.tsx:74
+#: src/components/VolumeControl.tsx:41
+#: src/components/VolumeControl.tsx:68
 msgid "Volume"
 msgstr "音量"
 


### PR DESCRIPTION
## Summary
- Replace WebKitGTK's built-in `navigator.mediaSession` MPRIS integration with a native Rust implementation using the `mpris-server` crate
- The player now appears as `museeks` in `playerctl -l` instead of `org.webkit.app-<hash>.Sandboxed.instance-<N>`
- On Linux, audio playback uses the Web Audio API instead of `<audio>` element to prevent WebKitGTK's MPRIS entry from reporting active playback status
- macOS/Windows continue to use `navigator.mediaSession`

## MPRIS features supported

- Play, pause, play/pause, stop, next, previous
- Shuffle (get/set)
- Loop status (None/Track/Playlist)
- Volume (get/set, with perceptual scaling matching the UI slider)
- Seek (absolute and relative)
- Position tracking
- Track metadata (title, artist, album, track number, duration, cover art)

## Changes

### Backend (Rust)
- **New:** `src-tauri/src/plugins/mpris.rs` — Native MPRIS server plugin using `mpris-server` crate with bidirectional IPC
- **Modified:** `src-tauri/src/plugins/stream_server.rs` — Added CORS header for Web Audio API `fetch()` compatibility
- **Modified:** `src-tauri/src/libs/events.rs` — Added `PlaybackSeekTo`, `PlaybackSeekBy`, `PlaybackSetVolume`,
`PlaybackSetShuffle`, `PlaybackSetRepeat` IPC events

### Frontend (TypeScript)
- **New:** `src/lib/bridge-mpris.ts` — IPC bridge for MPRIS commands (no-op on non-Linux)
- **New:** `src/lib/web-audio-element.ts` — Drop-in `HTMLAudioElement` replacement using `AudioContext` so WebKitGTK's MPRIS
 entry stays inactive
- **Modified:** `src/lib/player.ts` — Uses `WebAudioElement` on Linux, syncs state to native MPRIS, adds
`setShuffle`/`setRepeat` methods
- **Modified:** `src/lib/utils-player.ts` — Extracted shared volume smoothing helpers
- **Modified:** `src/components/VolumeControl.tsx` — Uses shared volume smoothing helpers
- **Modified:** `src/components/IPCPlayerEvents.tsx` — Handles new MPRIS-originated events (seek, volume, shuffle, repeat)

## Test plan

- [ ] `playerctl -l` shows `museeks` (the `org.webkit.app-...` entry may exist but stays in Stopped status)
- [ ] `playerctl metadata` shows title, artist, album, artUrl, length
- [ ] `playerctl play`, `pause`, `play-pause`, `next`, `previous`, `stop`
- [ ] `playerctl shuffle On` / `Off`
- [ ] `playerctl loop None` / `Track` / `Playlist`
- [ ] `playerctl volume 0.5` sets the UI slider to 50%
- [ ] `playerctl position 30` (absolute) and `playerctl position 10+` (relative)
- [ ] Desktop environment media controls (GNOME/KDE) work
- [ ] App builds and runs on macOS/Windows (MPRIS code is cfg-gated, mediaSession still works)